### PR TITLE
:mute: Don't show error stack in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .idea
-.keys.json

--- a/apis/query/Dockerfile-deploy
+++ b/apis/query/Dockerfile-deploy
@@ -25,4 +25,4 @@ COPY src/lib/dune/query.py dist/lib/dune
 
 EXPOSE 3000
 
-CMD ["npm", "run" ,"nps", "start.hosted "]
+CMD ["npm", "run" ,"nps", "start.prod "]

--- a/apis/query/docker-compose-dev.yaml
+++ b/apis/query/docker-compose-dev.yaml
@@ -6,7 +6,7 @@ services:
        context: .
        dockerfile: Dockerfile-dev
      environment:
-       GOOGLE_APPLICATION_CREDENTIALS: /run/secrets/google_credentials
+       GOOGLE_APPLICATION_CREDENTIALS_FILE: /run/secrets/google_credentials
        GOOGLE_CLOUD_PROJECT: ${GOOGLE_CLOUD_PROJECT}
        PYTHON: python3
        DUNE_USER: ${DUNE_USER}

--- a/apis/query/docker-compose.yaml
+++ b/apis/query/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
    query-api:
      build: .
      environment:
-       GOOGLE_APPLICATION_CREDENTIALS: /run/secrets/google_credentials
+       GOOGLE_APPLICATION_CREDENTIALS_FILE: /run/secrets/google_credentials
        GOOGLE_CLOUD_PROJECT: ${GOOGLE_CLOUD_PROJECT}
        PYTHON: python3
        DUNE_USER: ${DUNE_USER}

--- a/apis/query/package-scripts.yaml
+++ b/apis/query/package-scripts.yaml
@@ -56,9 +56,6 @@ scripts:
     prod:
       script: 'NODE_ENV=production node -r module-alias/register ./dist'
       hiddenFromHelp: true
-    hosted:
-      script: 'NODE_ENV=hosted node -r module-alias/register ./dist'
-      hiddenFromHelp: true
     default:
       script: 'nps build start.prod'
       description: 'Start project (prod)'

--- a/apis/query/secrets-entrypoint.sh
+++ b/apis/query/secrets-entrypoint.sh
@@ -23,6 +23,7 @@ file_env() {
 }
 
 file_env "DUNE_PWD"
+file_env "GOOGLE_APPLICATION_CREDENTIALS"
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then

--- a/apis/query/src/config/index.ts
+++ b/apis/query/src/config/index.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 
 const BASE_FOLDER = path.join(__dirname, '..', 'api')
-const ext = process.env.NODE_ENV === 'development' ? 'ts' : 'js'
+const ext = process.env.NODE_ENV === 'production' ? 'js' : 'ts'
 
 export const controllers = [path.join(BASE_FOLDER, 'controllers', `*.${ext}`)]
 export const middlewares = [path.join(BASE_FOLDER, 'middlewares', `*.${ext}`)]

--- a/apis/query/src/lib/bigquery.ts
+++ b/apis/query/src/lib/bigquery.ts
@@ -10,16 +10,20 @@ export class Db extends BigQuery {
       NODE_ENV,
     } = process.env
 
-    if (NODE_ENV !== 'test') {
+    if (NODE_ENV === 'test') {
+      super({
+        credentials: {},
+        projectId: '',
+      })
+    } else {
       if (GOOGLE_APPLICATION_CREDENTIALS === undefined)
         throw new Error('missing google credentials')
       if (projectId === undefined) throw new Error('missing google project id')
-    }
 
-    super({
-      // @ts-expect-error
-      credentials: JSON.parse(GOOGLE_APPLICATION_CREDENTIALS),
-      projectId,
-    })
+      super({
+        credentials: JSON.parse(GOOGLE_APPLICATION_CREDENTIALS),
+        projectId,
+      })
+    }
   }
 }

--- a/apis/query/src/lib/bigquery.ts
+++ b/apis/query/src/lib/bigquery.ts
@@ -16,17 +16,10 @@ export class Db extends BigQuery {
       if (projectId === undefined) throw new Error('missing google project id')
     }
 
-    if (process.env.NODE_ENV === 'hosted') {
-      super({
-        // @ts-expect-error
-        credentials: JSON.parse(GOOGLE_APPLICATION_CREDENTIALS),
-        projectId,
-      })
-    } else {
-      super({
-        keyFilename: GOOGLE_APPLICATION_CREDENTIALS,
-        projectId,
-      })
-    }
+    super({
+      // @ts-expect-error
+      credentials: JSON.parse(GOOGLE_APPLICATION_CREDENTIALS),
+      projectId,
+    })
   }
 }


### PR DESCRIPTION
- don't show errors stack in production
- always use a parsed GOOGLE_APPLICATION_CREDENTIALS json string env variable instead of a filename (big query constructor parameter: `credentials` instead of `keyFilename`)