### PR TITLE
fix circom ecdsa relative imports

### DIFF
--- a/circuits/circom/.gitignore
+++ b/circuits/circom/.gitignore
@@ -1,0 +1,7 @@
+# circom/snarkjs artifacts
+*.r1cs
+*.sym
+
+# test artifacts
+*_js
+

--- a/circuits/circom/maybe-fix-circom-imports.sh
+++ b/circuits/circom/maybe-fix-circom-imports.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+dest="$PWD/node_modules/circom-ecdsa/node_modules"
+
+if [[ ! -d $dir ]];then
+  src=node_modules/circomlib
+  cp -r $src $dest
+fi

--- a/circuits/circom/maybe-fix-circom-imports.sh
+++ b/circuits/circom/maybe-fix-circom-imports.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-dest="$PWD/node_modules/circom-ecdsa/node_modules"
+dest="$PWD/node_modules/circom-ecdsa/node_modules/circomlib"
 
 if [[ ! -d $dir ]];then
-  src=node_modules/circomlib
+  mkdir -p $dest
+  src=node_modules/circomlib/circuits
   cp -r $src $dest
 fi

--- a/circuits/circom/package.json
+++ b/circuits/circom/package.json
@@ -4,14 +4,14 @@
   "description": "Prove membership in a poseidon merkle tree by proving an ECDSA signature",
   "main": "",
   "scripts": {
-    "test": "mocha --max-old-space-size=4000 -r ts-node/register test/circuit.test.ts"
+    "test": "sh maybe-fix-circom-imports.sh && mocha --max-old-space-size=4000 -r ts-node/register test/circuit.test.ts"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "chai": "^4.3.7",
-    "circom_tester": "^0.0.19",
     "circom-ecdsa": "github:0xPARC/circom-ecdsa",
+    "circom_tester": "^0.0.19",
     "circomlib": "^2.0.5",
     "circomlibjs": "^0.1.7",
     "hardhat": "^2.12.2",


### PR DESCRIPTION
The issue with
```
Error: Command failed: circom --wasm --sym --r1cs --output /var/folders/2z/nhf2fw552532063grgl430hw0000gn/T/circom_-66408-kxdKM1OtM12Z /Users/r1oga/dev/e2e-zk-ecdsa/circuits/circom/test/membership_test.circom
error[P1000]: Include not found: ../node_modules/circomlib/circuits/comparators.circom
```

isn't update temp files, it is about relative imports used in `circom-ecdsa`.  
- `circom-ecdsa` is installed using a github url
- `circomlib` is installed as an npm package
- but `circom-ecdsa` circuits expect the circomlib circuits to live somewhere else. See [here](https://github.com/0xPARC/circom-ecdsa/blob/d87eb7068cb35c951187093abe966275c1839ead/circuits/bigint.circom#L3-L5)

The circom-ecdsa circuits expect a folder structure like:
```
e2e-zk-ecdsa/circuits/circom/node_modules
   circom-ecdsa
      node_modules
         circomlib
            circuits
              ...

```
But when simply installing a package.json like:
```
"circom-ecdsa": "github:0xPARC/circom-ecdsa",
"circomlib": "^2.0.5",
```

What we get is:
```
e2e-zk-ecdsa/circuits/circom/node_modules
   circom-ecdsa
   circomlib
```
where `node_modules/circom-ecdsa/node_modules/circomlib` really doesn't exist!

Several ways to fix it:
1. create soft links between `node_modules/circomlib` and `node_modules/circon-ecdsa/node_modules/circomlib`
   Could not work on all OSes (windows vs Mac vs Linux...)
2.  Change the `include` lines in the circuits to `../../circomlib/...`
   Need to fork the repo. Many files to edit...
3. Perform a manual install inside the `circom-ecdsa` folder
   ```
   cd node_modules/circom-ecdsa
   yarn
   ```
   Would actually install all the deps used by this repo. Some aren't necessary here
4. copy the circuits from `node_modules/circomlib` to `node_modules/circom-ecdsa/node_modules`
   **Still a bit hacky but that is straightforward. This is what this PR suggests doing**

