### PR TITLE
Non Membership Proofs

### DIFF
--- a/circuits/circom/membership.circom
+++ b/circuits/circom/membership.circom
@@ -43,10 +43,11 @@ template InAddressSet(n, k, levels) {
 
 // Proves that a message is signed by an address which is not in the merkle tree
 // We show that the signer's address would be between two adjacent addresses in a sorted list
-// This assumes that the list is sorted, which should generally be done outside the circuit
+// This assumes that the list is sorted, which should generally be done outside the circuit.
+// If sorted is impossible, you need a different algorithm, as explained here https://crypto.stackexchange.com/a/31915
 template NotInAddressSet(n, k, levels) {
     signal input pubkey[2][k];
-    
+
     // Signature
     signal input r[k];
     signal input s[k];
@@ -112,7 +113,7 @@ template NotInAddressSet(n, k, levels) {
 
 template ValidateSignatureForAddress(n, k) {
     signal input pubkey[2][k];
-    
+
     // Signature
     signal input r[k];
     signal input s[k];

--- a/circuits/circom/membership.circom
+++ b/circuits/circom/membership.circom
@@ -2,6 +2,8 @@ pragma circom 2.0.2;
 
 include "node_modules/circom-ecdsa/circuits/zk-identity/eth.circom";
 include "node_modules/circom-ecdsa/circuits/ecdsa.circom";
+include "node_modules/circomlib/circuits/bitify.circom";
+include "node_modules/circomlib/circuits/comparators.circom";
 include "./merkleTree.circom";
 
 // Proves that a message is signed by one of the addresses in a merkle tree
@@ -19,6 +21,104 @@ template InAddressSet(n, k, levels) {
     signal input root;
     signal input pathElements[levels];
     signal input pathIndices[levels];
+
+    component validator = ValidateSignatureForAddress(n, k);
+    for (var i = 0; i < k; i++) {
+        validator.pubkey[0][i] = pubkey[0][i];
+        validator.pubkey[1][i] = pubkey[1][i];
+        validator.r[i] = r[i];
+        validator.s[i] = s[i];
+        validator.msghash[i] = msghash[i];
+    }
+
+    // Check address is in set
+    component tree = MerkleTreeChecker(levels);
+    tree.leaf <== validator.address;
+    tree.root <== root;
+    for (var i = 0; i < levels; i++) {
+        tree.pathElements[i] <== pathElements[i];
+        tree.pathIndices[i] <== pathIndices[i];
+    }
+}
+
+// Proves that a message is signed by an address which is not in the merkle tree
+// We show that the signer's address would be between two adjacent addresses in a sorted list
+// This assumes that the list is sorted, which should generally be done outside the circuit
+template NotInAddressSet(n, k, levels) {
+    signal input pubkey[2][k];
+    
+    // Signature
+    signal input r[k];
+    signal input s[k];
+    signal input msghash[k];
+
+    // Merkle proofs
+    signal input root;
+    signal input pathElements[2][levels];
+    signal input pathIndices[levels];
+    signal leaves[2];
+
+    component validator = ValidateSignatureForAddress(n, k);
+    for (var i = 0; i < k; i++) {
+        validator.pubkey[0][i] = pubkey[0][i];
+        validator.pubkey[1][i] = pubkey[1][i];
+        validator.r[i] = r[i];
+        validator.s[i] = s[i];
+        validator.msghash[i] = msghash[i];
+    }
+
+    // Make sure the indices are adjacent
+    var belowSum = 0;
+    var aboveSum = 0;
+    for (var i = 0; i < levels; i++) {
+        belowSum += (1 << i) * pathIndices[0][i];
+        aboveSum += (1 << i) * pathIndices[1][i];
+    }
+    aboveSum === belowSum + 1;
+
+    // Check both leaf addresses are in the merkle tree
+    component merkleProofs[2];
+    for (var i = 0; i < 2; i++) {
+        merkleProofs[i] = MerkleTreeChecker(levels);
+        merkleProofs[i].leaf <== leaves[i];
+        merkleProofs[i].root <== root;
+        for (var j = 0; j < levels; j++) {
+            merkleProofs[i].pathElements[j] <== pathElements[i][j];
+            merkleProofs[i].pathIndices[j] <== pathIndices[i][j];
+        }
+    }
+
+    // Make sure below < signer < above
+    // Range check the addresses to make sure they're 160-bit numbers (should in principle be done by the keccak circuit, but it's experimental)
+    component rangeCheck[3];
+    for (var i = 0; i < 3; i++) {
+        rangeCheck[i] = Num2Bits(160);
+    }
+    rangeCheck[0].in <== leaves[0];
+    rangeCheck[0].in <== validator.address;
+    rangeCheck[0].in <== leaves[1];
+
+    component lt[2];
+    for (var i = 0; i < 2; i++) {
+        lt[i] = LessThan(160);
+    }
+
+    lt[0].in[0] <== leaves[0];
+    lt[0].in[1] <== validator.address;
+
+    lt[1].in[0] <== validator.address;
+    lt[1].in[1] <== leaves[1];
+}
+
+template ValidateSignatureForAddress(n, k) {
+    signal input pubkey[2][k];
+    
+    // Signature
+    signal input r[k];
+    signal input s[k];
+    signal input msghash[k];
+
+    signal out address;
 
     // Validate public key
     component pubKeyCheck = ECDSACheckPubKey(n, k);
@@ -44,17 +144,9 @@ template InAddressSet(n, k, levels) {
         flatten.chunkedPubkey[1][i] <== pubkey[1][i];
     }
 
-    component address = PubkeyToAddress();
+    component pubkeyToAddress = PubkeyToAddress();
     for (var i = 0; i < 512; i++) {
-        address.pubkeyBits[i] <== flatten.pubkeyBits[i];
+        pubkeyToAddress.pubkeyBits[i] <== flatten.pubkeyBits[i];
     }
-
-    // Check address is in set
-    component tree = MerkleTreeChecker(levels);
-    tree.leaf <== address.address;
-    tree.root <== root;
-    for (var i = 0; i < levels; i++) {
-        tree.pathElements[i] <== pathElements[i];
-        tree.pathIndices[i] <== pathIndices[i];
-    }
+    address <== pubkeyToAddress.address;
 }

--- a/circuits/circom/test/circuit.test.ts
+++ b/circuits/circom/test/circuit.test.ts
@@ -14,7 +14,7 @@ import {
   uint8ArrayToBigint,
 } from './helpers'
 
-jest.setTimeout(1_000_000)
+jest.setTimeout(10_000_000) // ~1 hour
 
 describe('Poseidon Merkle Tree', function () {
   let poseidon

--- a/circuits/circom/test/circuit.test.ts
+++ b/circuits/circom/test/circuit.test.ts
@@ -7,7 +7,10 @@ import { join } from 'path'
 import {
   bigintToArray,
   bigintToUint8Array,
+  ExcludableMerkleTree,
+  maxAddress,
   MerkleTree,
+  minAddress,
   uint8ArrayToBigint,
 } from './helpers'
 
@@ -43,6 +46,16 @@ describe('Poseidon Merkle Tree', function () {
     const tree = new MerkleTree([0n, 1n, 2n, 3n], 3, poseidon, F)
 
     expect(tree.merkleProof(1)).toEqual({ pathElements, pathIndices })
+  })
+
+  it('Should generate exclusion proofs', () => {
+    expect(new ExcludableMerkleTree([10n, 1000n], 3, poseidon, F).exclusionProof(99n)).toEqual(
+      {
+        leaves: [10n, 1000n],
+        pathIndices: [1, 0],
+        pathElements: [[minAddress, F.toObject(poseidon([1000n, maxAddress]))], [maxAddress, F.toObject(poseidon([minAddress, 10n]))]],
+      }
+    )
   })
 
   it('Should generate merkle roots', () => {

--- a/circuits/circom/test/circuit.test.ts
+++ b/circuits/circom/test/circuit.test.ts
@@ -179,7 +179,9 @@ describe('SetMembership', function () {
   )
 
   beforeAll(async function () {
-    membershipCircuit = await wasm_tester(join(__dirname, 'membership_test.circom'))
+    membershipCircuit = await wasm_tester(
+      join(__dirname, 'membership_test.circom'),
+    )
     nonMembershipCircuit = await wasm_tester(
       join(__dirname, 'non_membership_test.circom'),
     )

--- a/circuits/circom/test/circuit.test.ts
+++ b/circuits/circom/test/circuit.test.ts
@@ -179,7 +179,7 @@ describe('SetMembership', function () {
   )
 
   beforeAll(async function () {
-    // membershipCircuit = await wasm_tester(join(__dirname, 'membership_test.circom'))
+    membershipCircuit = await wasm_tester(join(__dirname, 'membership_test.circom'))
     nonMembershipCircuit = await wasm_tester(
       join(__dirname, 'non_membership_test.circom'),
     )

--- a/circuits/circom/test/helpers.ts
+++ b/circuits/circom/test/helpers.ts
@@ -1,5 +1,5 @@
-export const minAddress = 0n;
-export const maxAddress = (2n ** 160n) - 1n;
+export const minAddress = 0n
+export const maxAddress = 2n ** 160n - 1n
 
 // Merkle tree of a specified depth padded with zeroes.
 // One zero is added per layer at most, so we can create very deep trees with few elements,
@@ -16,7 +16,7 @@ export class MerkleTree {
     }
 
     for (let i = 0; i < elements.length; i++) {
-      const element = elements[i];
+      const element = elements[i]
       if (element < minAddress || element > maxAddress) {
         throw new Error(
           `Element number ${i} with value ${element} is out of range`,
@@ -60,41 +60,44 @@ export class ExcludableMerkleTree extends MerkleTree {
     // so all possible addresses fall in the range.
     // Note that the current implementation doesn't allow one to prove exclusion for the zero address or
     // the address with the value 2^160-1, this is a relatively small trade off for simplicity.
-    elements.sort((a, b) => (a < b) ? -1 : ((a > b) ? 1 : 0));
+    elements.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
 
-    if (elements[0] > minAddress) elements.unshift(minAddress);
-    if (elements[0] < maxAddress) elements.push(maxAddress);
+    if (elements[0] > minAddress) elements.unshift(minAddress)
+    if (elements[0] < maxAddress) elements.push(maxAddress)
 
-    super(elements, depth, hashFunction, field);
+    super(elements, depth, hashFunction, field)
   }
 
   exclusionProof(nonMember: bigint): {
-    leaves: [bigint, bigint],
-    pathIndices: [number[], number[]];
-    pathElements: [bigint[], bigint[]];
-  }{
+    leaves: [bigint, bigint]
+    pathIndices: [number[], number[]]
+    pathElements: [bigint[], bigint[]]
+  } {
     // Find the index of the leaf that would be immediately before the non member (TODO: binary search)
-    let leftLeafIndex = 0;
-    while (this.levels[0][leftLeafIndex+1] < nonMember && leftLeafIndex < this.levels[0].length) {
-      leftLeafIndex++;
+    let leftLeafIndex = 0
+    while (
+      this.levels[0][leftLeafIndex + 1] < nonMember &&
+      leftLeafIndex < this.levels[0].length
+    ) {
+      leftLeafIndex++
     }
 
-    const leftLeaf = this.levels[0][leftLeafIndex];
-    const rightLeaf = this.levels[0][leftLeafIndex+1]
+    const leftLeaf = this.levels[0][leftLeafIndex]
+    const rightLeaf = this.levels[0][leftLeafIndex + 1]
     if (leftLeaf >= nonMember || rightLeaf <= nonMember) {
       throw new Error(
-        `Could not produce exclusion proof. Left leaf: ${leftLeaf}, right leaf: ${rightLeaf}, value: ${nonMember}`
+        `Could not produce exclusion proof. Left leaf: ${leftLeaf}, right leaf: ${rightLeaf}, value: ${nonMember}`,
       )
     }
 
     // Calculate the paths to the leaves
-    const leftProof = this.merkleProof(leftLeafIndex);
-    const rightProof = this.merkleProof(leftLeafIndex+1);
+    const leftProof = this.merkleProof(leftLeafIndex)
+    const rightProof = this.merkleProof(leftLeafIndex + 1)
 
-    return { 
+    return {
       leaves: [leftLeaf, rightLeaf],
-      pathIndices: [leftProof.pathIndices, rightProof.pathIndices],
       pathElements: [leftProof.pathElements, rightProof.pathElements],
+      pathIndices: [leftProof.pathIndices, rightProof.pathIndices],
     }
   }
 }

--- a/circuits/circom/test/helpers.ts
+++ b/circuits/circom/test/helpers.ts
@@ -1,3 +1,6 @@
+const minAddress = 0n;
+const maxAddress = BigInt((2 >> 160) - 1);
+
 // Merkle tree of a specified depth padded with zeroes.
 // One zero is added per layer at most, so we can create very deep trees with few elements,
 // meaning that we can efficiently make merkle proofs for many sizes of sets, while using a single circuit.
@@ -12,9 +15,19 @@ export class MerkleTree {
       )
     }
 
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
+      if (element < minAddress || element > maxAddress) {
+        throw new Error(
+          `Element number ${i} with value ${element} is out of range`,
+        )
+      }
+    }
+
     this.depth = depth
     this.levels = []
     this.levels[0] = elements
+
     for (let i = 1; i < depth; i++) {
       this.levels[i] = hashLevel(this.levels[i - 1], hashFunction, field)
     }
@@ -36,6 +49,53 @@ export class MerkleTree {
       index = index >> 1
     }
     return { pathElements, pathIndices }
+  }
+}
+
+export class ExcludableMerkleTree extends MerkleTree {
+  constructor(elements: bigint[], depth: number, hashFunction, field) {
+    // Exclusion works by proving merkle proofs for two adjacent values on a sorted list, such that the
+    // element being proven should fall between them.
+    // So we have to sort the list for soundess, and add min and max values to the end of the list
+    // so all possible addresses fall in the range.
+    // Note that the current implementation doesn't allow one to prove exclusion for the zero address or
+    // the address with the value 2^160-1, this is a relatively small trade off for simplicity.
+    elements.sort((a, b) => (a < b) ? -1 : ((a > b) ? 1 : 0));
+
+    if (elements[0] > minAddress) elements.unshift(minAddress);
+    if (elements[0] < maxAddress) elements.push(maxAddress);
+
+    super(elements, depth, hashFunction, field);
+  }
+
+  exclusionProof(nonMember: bigint): {
+    leaves: [bigint, bigint],
+    pathIndices: number[]; // Path to the first leaf
+    pathElements: [bigint[], bigint[]];
+  }{
+    // Find the index of the leaf that would be immediately before the non member
+    let leftLeafIndex = 0;
+    while (this.levels[0][leftLeafIndex] < nonMember && leftLeafIndex < this.levels[0].length) {
+      leftLeafIndex++;
+    }
+
+    const leftLeaf = this.levels[0][leftLeafIndex];
+    const rightLeaf = this.levels[0][leftLeafIndex+1]
+    if (leftLeaf >= nonMember || rightLeaf <= nonMember) {
+      throw new Error(
+        `Could not produce exclusion proof. Left leaf: ${leftLeaf}, right leaf: ${rightLeaf}, value: ${nonMember}`
+      )
+    }
+
+    // Calculate the paths to the leaves
+    const leftProof = this.merkleProof(leftLeafIndex);
+    const rightProof = this.merkleProof(leftLeafIndex+1);
+
+    return { 
+      leaves: [leftLeaf, rightLeaf],
+      pathIndices: leftProof.pathIndices,
+      pathElements: [leftProof.pathElements, rightProof.pathElements],
+    }
   }
 }
 

--- a/circuits/circom/test/helpers.ts
+++ b/circuits/circom/test/helpers.ts
@@ -70,10 +70,10 @@ export class ExcludableMerkleTree extends MerkleTree {
 
   exclusionProof(nonMember: bigint): {
     leaves: [bigint, bigint],
-    pathIndices: number[]; // Path to the first leaf
+    pathIndices: [number[], number[]];
     pathElements: [bigint[], bigint[]];
   }{
-    // Find the index of the leaf that would be immediately before the non member
+    // Find the index of the leaf that would be immediately before the non member (TODO: binary search)
     let leftLeafIndex = 0;
     while (this.levels[0][leftLeafIndex+1] < nonMember && leftLeafIndex < this.levels[0].length) {
       leftLeafIndex++;
@@ -93,7 +93,7 @@ export class ExcludableMerkleTree extends MerkleTree {
 
     return { 
       leaves: [leftLeaf, rightLeaf],
-      pathIndices: leftProof.pathIndices,
+      pathIndices: [leftProof.pathIndices, rightProof.pathIndices],
       pathElements: [leftProof.pathElements, rightProof.pathElements],
     }
   }

--- a/circuits/circom/test/helpers.ts
+++ b/circuits/circom/test/helpers.ts
@@ -1,5 +1,5 @@
-const minAddress = 0n;
-const maxAddress = BigInt((2 >> 160) - 1);
+export const minAddress = 0n;
+export const maxAddress = (2n ** 160n) - 1n;
 
 // Merkle tree of a specified depth padded with zeroes.
 // One zero is added per layer at most, so we can create very deep trees with few elements,
@@ -75,7 +75,7 @@ export class ExcludableMerkleTree extends MerkleTree {
   }{
     // Find the index of the leaf that would be immediately before the non member
     let leftLeafIndex = 0;
-    while (this.levels[0][leftLeafIndex] < nonMember && leftLeafIndex < this.levels[0].length) {
+    while (this.levels[0][leftLeafIndex+1] < nonMember && leftLeafIndex < this.levels[0].length) {
       leftLeafIndex++;
     }
 

--- a/circuits/circom/test/non_membership_test.circom
+++ b/circuits/circom/test/non_membership_test.circom
@@ -1,0 +1,5 @@
+pragma circom 2.0.2;
+
+include "../membership.circom";
+
+component main {public [msghash, root]} = NotInAddressSet(64, 4, 2);


### PR DESCRIPTION
This adds a circuit for making zk proofs of non membership in a merkle tree.
It also provides a TS class for preprocessing the tree to easily get the relevant data.
The tests show that our circuits accept some arbitrary valid non membership proof.

[This stackexchange post](https://crypto.stackexchange.com/a/56122) explains the algorithm well.