### PR TITLE
fix: include `circuits/circom/prover` in files watched by tsc

### DIFF
--- a/circuits/circom/tsconfig.json
+++ b/circuits/circom/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "strictNullChecks": true
   },
-  "include": ["test", "jest.config.ts"]
+  "include": ["prover", "test", "jest.config.ts"]
 }


### PR DESCRIPTION
Otherwise it breaks eslint
```
Parsing error: ESLint was configured to run on `<tsconfigRootDir>/circuits/circom/prover/test_client.ts` using `parserOptions.project`
```
