### PR TITLE
bug: Paginate over the graph results

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -4,12 +4,10 @@ on:
   # pull_request required to get PR comments
   pull_request:
     branches: [main, staging]
-    paths: ['apis', 'circuits']
-    paths-ignore: ['**/*md', '**/*yaml', '**/*yml']
+    paths: ['apis', 'circuits', '!**/*md', '!**/*yaml', '!**/*yml']
   push:
     branches: [main, staging]
-    paths: ['apis', 'circuits']
-    paths-ignore: ['**/*md', '**/*yaml', '**/*yml']
+    paths: ['apis', 'circuits', '!**/*md', '!**/*yaml', '!**/*yml']
 
 jobs:
   coveralls:

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -4,10 +4,10 @@ on:
   # pull_request required to get PR comments
   pull_request:
     branches: [main, staging]
-    paths: ['apis', 'circuits', '!**/*md', '!**/*yaml', '!**/*yml']
+    paths: ['apis/**', 'circuits/**', '!**/*md', '!**/*yaml', '!**/*yml']
   push:
     branches: [main, staging]
-    paths: ['apis', 'circuits', '!**/*md', '!**/*yaml', '!**/*yml']
+    paths: ['apis/**', 'circuits/**', '!**/*md', '!**/*yaml', '!**/*yml']
 
 jobs:
   coveralls:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,12 +2,10 @@ name: Snyk Security Checks
 on:
   pull_request:
     branches: [main, staging]
-    paths: ['apis', 'circuits']
-    paths-ignore: ['**/*md', '**/*yaml', '**/*yml']
+    paths: ['apis', 'circuits', '!**/*md', '!**/*yaml', '!**/*yml']
   push:
     branches: [main, staging]
-    paths: ['apis', 'circuits']
-    paths-ignore: ['**/*md', '**/*yaml', '**/*yml']
+    paths: ['apis', 'circuits', '!**/*md', '!**/*yaml', '!**/*yml']
 
 jobs:
   security:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,10 +2,10 @@ name: Snyk Security Checks
 on:
   pull_request:
     branches: [main, staging]
-    paths: ['apis', 'circuits', '!**/*md', '!**/*yaml', '!**/*yml']
+    paths: ['apis/**', 'circuits/**', '!**/*md', '!**/*yaml', '!**/*yml']
   push:
     branches: [main, staging]
-    paths: ['apis', 'circuits', '!**/*md', '!**/*yaml', '!**/*yml']
+    paths: ['apis/**', 'circuits/**', '!**/*md', '!**/*yaml', '!**/*yml']
 
 jobs:
   security:

--- a/apis/query/src/api/controllers/requests/getEnsProposalVotersQuery.ts
+++ b/apis/query/src/api/controllers/requests/getEnsProposalVotersQuery.ts
@@ -5,7 +5,7 @@ import { VoteChoice } from '~/graph'
 export class getEnsProposalVotersQuery {
   @IsDefined()
   @IsNumberString({ no_symbols: true })
-  @Length(78, 78)
+  @Length(77, 78)
   id: string
 
   @IsDefined()

--- a/apis/query/src/api/repositories/GraphRepository.ts
+++ b/apis/query/src/api/repositories/GraphRepository.ts
@@ -20,7 +20,7 @@ export class GraphRepository {
       | typeof PunkOwnersDocument
       | typeof VotersPerProposalDocument,
     variables: T,
-    resultFn: (arg0: any)=> U[],
+    resultFn: (arg0: any) => U[],
     idFn: (arg0: U) => string,
   ): Promise<string[]> {
     let current: U[] | undefined
@@ -63,7 +63,7 @@ export class GraphRepository {
     >(
       VotersPerProposalDocument,
       { choice, id },
-      data => data.proposal.votes,
+      (data) => data.proposal.votes,
       (vote) => vote.voter.id,
     )
   }
@@ -72,7 +72,7 @@ export class GraphRepository {
     return this.autoPage<object, Punk>(
       PunkOwnersDocument,
       {},
-      data => data.punks,
+      (data) => data.punks,
       (punk) => punk.owner.id,
     )
   }
@@ -81,7 +81,7 @@ export class GraphRepository {
     return this.autoPage<object, Depositor>(
       BeaconDepositorsDocument,
       {},
-      data => data.depositors,
+      (data) => data.depositors,
       (depositor) => depositor.id,
     )
   }

--- a/apis/query/src/api/repositories/GraphRepository.ts
+++ b/apis/query/src/api/repositories/GraphRepository.ts
@@ -20,7 +20,7 @@ export class GraphRepository {
       | typeof PunkOwnersDocument
       | typeof VotersPerProposalDocument,
     variables: T,
-    key: string,
+    resultFn: (arg0: any)=> U[],
     idFn: (arg0: U) => string,
   ): Promise<string[]> {
     let current: U[] | undefined
@@ -29,7 +29,7 @@ export class GraphRepository {
 
     while (current === undefined || current?.length > 0) {
       const { data } = await execute(query, { ...variables, skip })
-      current = data[key]
+      current = resultFn(data)
       if (current !== undefined) {
         for (const item of current) {
           const id = idFn(item).toLowerCase()
@@ -63,7 +63,7 @@ export class GraphRepository {
     >(
       VotersPerProposalDocument,
       { choice, id },
-      'proposal',
+      data => data.proposal.votes,
       (vote) => vote.voter.id,
     )
   }
@@ -72,7 +72,7 @@ export class GraphRepository {
     return this.autoPage<object, Punk>(
       PunkOwnersDocument,
       {},
-      'punks',
+      data => data.punks,
       (punk) => punk.owner.id,
     )
   }
@@ -81,7 +81,7 @@ export class GraphRepository {
     return this.autoPage<object, Depositor>(
       BeaconDepositorsDocument,
       {},
-      'depositors',
+      data => data.depositors,
       (depositor) => depositor.id,
     )
   }

--- a/apis/query/src/api/repositories/GraphRepository.ts
+++ b/apis/query/src/api/repositories/GraphRepository.ts
@@ -69,7 +69,11 @@ export class GraphRepository {
   }
 
   async getBeaconDepositors() {
-    const { data } = await execute(BeaconDepositorsDocument, {})
-    return (data?.depositors ?? []).map((depositor: Depositor) => depositor.id)
+    return this.autoPage(
+      BeaconDepositorsDocument,
+      {},
+      'depositors',
+      (depositor: Depositor) => depositor.id,
+    )
   }
 }

--- a/apis/query/src/api/repositories/GraphRepository.ts
+++ b/apis/query/src/api/repositories/GraphRepository.ts
@@ -15,6 +15,36 @@ import {
 
 @Service()
 export class GraphRepository {
+  async autoPage<T, U>(
+    query: any,
+    variables: T,
+    key: string,
+    idFn: (arg0: U) => string,
+  ): Promise<string[]> {
+    let current: U[] | undefined
+    let skip = 0
+    const results: string[] = []
+
+    while (current === undefined || current?.length > 0) {
+      const { data } = await execute(query, { ...variables, skip })
+      current = data[key]
+      if (current !== undefined) {
+        for (const item of current) {
+          const id = idFn(item).toLowerCase()
+          if (!results.includes(id)) {
+            results.push(id)
+          }
+        }
+      }
+
+      console.log(`Fetched ${results.length} results so far...`)
+
+      skip += 1000
+    }
+
+    return results
+  }
+
   async getEnsProposalVoters({
     choice,
     id,
@@ -30,8 +60,12 @@ export class GraphRepository {
   }
 
   async getPunkOwners(): Promise<string[]> {
-    const { data } = await execute(PunkOwnersDocument, {})
-    return (data?.punks ?? []).map((punk: Punk) => punk.owner.id)
+    return this.autoPage(
+      PunkOwnersDocument,
+      {},
+      'punks',
+      (punk: Punk) => punk.owner.id,
+    )
   }
 
   async getBeaconDepositors() {

--- a/apis/query/src/lib/graph/.graphclient/index.ts
+++ b/apis/query/src/lib/graph/.graphclient/index.ts
@@ -3370,6 +3370,8 @@ export type Aggregation_filter = {
   totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
 };
 
 export type Aggregation_orderBy =
@@ -3411,6 +3413,8 @@ export type DailyDeposit_filter = {
   dailyDepositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
 };
 
 export type DailyDeposit_orderBy =
@@ -3480,12 +3484,20 @@ export type Deposit_filter = {
   depositor_?: InputMaybe<Depositor_filter>;
   pubkey?: InputMaybe<Scalars['Bytes']>;
   pubkey_not?: InputMaybe<Scalars['Bytes']>;
+  pubkey_gt?: InputMaybe<Scalars['Bytes']>;
+  pubkey_lt?: InputMaybe<Scalars['Bytes']>;
+  pubkey_gte?: InputMaybe<Scalars['Bytes']>;
+  pubkey_lte?: InputMaybe<Scalars['Bytes']>;
   pubkey_in?: InputMaybe<Array<Scalars['Bytes']>>;
   pubkey_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   pubkey_contains?: InputMaybe<Scalars['Bytes']>;
   pubkey_not_contains?: InputMaybe<Scalars['Bytes']>;
   withdrawal_credentials?: InputMaybe<Scalars['Bytes']>;
   withdrawal_credentials_not?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_gt?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_lt?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_gte?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_lte?: InputMaybe<Scalars['Bytes']>;
   withdrawal_credentials_in?: InputMaybe<Array<Scalars['Bytes']>>;
   withdrawal_credentials_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   withdrawal_credentials_contains?: InputMaybe<Scalars['Bytes']>;
@@ -3508,12 +3520,17 @@ export type Deposit_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
 };
 
 export type Deposit_orderBy =
   | 'id'
   | 'dayID'
   | 'depositor'
+  | 'depositor__id'
+  | 'depositor__totalAmountDeposited'
+  | 'depositor__depositCount'
   | 'pubkey'
   | 'withdrawal_credentials'
   | 'amount'
@@ -3563,6 +3580,8 @@ export type Depositor_filter = {
   deposits_?: InputMaybe<Deposit_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
 };
 
 export type Depositor_orderBy =
@@ -3685,12 +3704,17 @@ export type AccountasksArgs = {
 export type Account_filter = {
   id?: InputMaybe<Scalars['Bytes']>;
   id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
   id_in?: InputMaybe<Array<Scalars['Bytes']>>;
   id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   id_contains?: InputMaybe<Scalars['Bytes']>;
   id_not_contains?: InputMaybe<Scalars['Bytes']>;
   punksOwned_?: InputMaybe<Punk_filter>;
   bought_?: InputMaybe<Sale_filter>;
+  nftsOwned_?: InputMaybe<NFT_filter>;
   assigned_?: InputMaybe<Assign_filter>;
   sent_?: InputMaybe<Transfer_filter>;
   received_?: InputMaybe<Transfer_filter>;
@@ -3782,6 +3806,8 @@ export type Account_filter = {
   accountUrl_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Account_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Account_filter>>>;
 };
 
 export type Account_orderBy =
@@ -3963,6 +3989,7 @@ export type AskCreated_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -3985,12 +4012,20 @@ export type AskCreated_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -4005,16 +4040,53 @@ export type AskCreated_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<AskCreated_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<AskCreated_filter>>>;
 };
 
 export type AskCreated_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'ask'
+  | 'ask__id'
+  | 'ask__open'
+  | 'ask__amount'
+  | 'ask__offerType'
   | 'amount'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -4164,6 +4236,7 @@ export type AskRemoved_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -4186,12 +4259,20 @@ export type AskRemoved_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -4206,16 +4287,53 @@ export type AskRemoved_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<AskRemoved_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<AskRemoved_filter>>>;
 };
 
 export type AskRemoved_orderBy =
   | 'id'
   | 'ask'
+  | 'ask__id'
+  | 'ask__open'
+  | 'ask__amount'
+  | 'ask__offerType'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -4285,6 +4403,7 @@ export type Ask_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   created?: InputMaybe<Scalars['String']>;
   created_not?: InputMaybe<Scalars['String']>;
   created_gt?: InputMaybe<Scalars['String']>;
@@ -4305,6 +4424,7 @@ export type Ask_filter = {
   created_ends_with_nocase?: InputMaybe<Scalars['String']>;
   created_not_ends_with?: InputMaybe<Scalars['String']>;
   created_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  created_?: InputMaybe<Event_filter>;
   removed?: InputMaybe<Scalars['String']>;
   removed_not?: InputMaybe<Scalars['String']>;
   removed_gt?: InputMaybe<Scalars['String']>;
@@ -4325,22 +4445,55 @@ export type Ask_filter = {
   removed_ends_with_nocase?: InputMaybe<Scalars['String']>;
   removed_not_ends_with?: InputMaybe<Scalars['String']>;
   removed_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  removed_?: InputMaybe<Event_filter>;
   offerType?: InputMaybe<OfferType>;
   offerType_not?: InputMaybe<OfferType>;
   offerType_in?: InputMaybe<Array<OfferType>>;
   offerType_not_in?: InputMaybe<Array<OfferType>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Ask_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Ask_filter>>>;
 };
 
 export type Ask_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'open'
   | 'amount'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'created'
+  | 'created__id'
+  | 'created__amount'
+  | 'created__type'
+  | 'created__logNumber'
+  | 'created__blockNumber'
+  | 'created__blockHash'
+  | 'created__txHash'
+  | 'created__timestamp'
   | 'removed'
+  | 'removed__id'
+  | 'removed__amount'
+  | 'removed__type'
+  | 'removed__logNumber'
+  | 'removed__blockNumber'
+  | 'removed__blockHash'
+  | 'removed__txHash'
+  | 'removed__timestamp'
   | 'offerType';
 
 export type Assign = Event & {
@@ -4412,6 +4565,7 @@ export type Assign_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   to?: InputMaybe<Scalars['String']>;
   to_not?: InputMaybe<Scalars['String']>;
   to_gt?: InputMaybe<Scalars['String']>;
@@ -4484,12 +4638,20 @@ export type Assign_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -4504,15 +4666,48 @@ export type Assign_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Assign_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Assign_filter>>>;
 };
 
 export type Assign_orderBy =
   | 'id'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'type'
   | 'logNumber'
   | 'blockNumber'
@@ -4679,6 +4874,7 @@ export type BidCreated_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -4701,12 +4897,20 @@ export type BidCreated_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -4721,16 +4925,53 @@ export type BidCreated_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<BidCreated_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<BidCreated_filter>>>;
 };
 
 export type BidCreated_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'bid'
+  | 'bid__id'
+  | 'bid__open'
+  | 'bid__amount'
+  | 'bid__offerType'
   | 'amount'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -4880,6 +5121,7 @@ export type BidRemoved_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -4902,12 +5144,20 @@ export type BidRemoved_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -4922,16 +5172,53 @@ export type BidRemoved_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<BidRemoved_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<BidRemoved_filter>>>;
 };
 
 export type BidRemoved_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'bid'
+  | 'bid__id'
+  | 'bid__open'
+  | 'bid__amount'
+  | 'bid__offerType'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -5001,6 +5288,7 @@ export type Bid_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   created?: InputMaybe<Scalars['String']>;
   created_not?: InputMaybe<Scalars['String']>;
   created_gt?: InputMaybe<Scalars['String']>;
@@ -5021,6 +5309,7 @@ export type Bid_filter = {
   created_ends_with_nocase?: InputMaybe<Scalars['String']>;
   created_not_ends_with?: InputMaybe<Scalars['String']>;
   created_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  created_?: InputMaybe<Event_filter>;
   removed?: InputMaybe<Scalars['String']>;
   removed_not?: InputMaybe<Scalars['String']>;
   removed_gt?: InputMaybe<Scalars['String']>;
@@ -5041,22 +5330,55 @@ export type Bid_filter = {
   removed_ends_with_nocase?: InputMaybe<Scalars['String']>;
   removed_not_ends_with?: InputMaybe<Scalars['String']>;
   removed_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  removed_?: InputMaybe<Event_filter>;
   offerType?: InputMaybe<OfferType>;
   offerType_not?: InputMaybe<OfferType>;
   offerType_in?: InputMaybe<Array<OfferType>>;
   offerType_not_in?: InputMaybe<Array<OfferType>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Bid_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Bid_filter>>>;
 };
 
 export type Bid_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'open'
   | 'amount'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'created'
+  | 'created__id'
+  | 'created__amount'
+  | 'created__type'
+  | 'created__logNumber'
+  | 'created__blockNumber'
+  | 'created__blockHash'
+  | 'created__txHash'
+  | 'created__timestamp'
   | 'removed'
+  | 'removed__id'
+  | 'removed__amount'
+  | 'removed__type'
+  | 'removed__logNumber'
+  | 'removed__blockNumber'
+  | 'removed__blockHash'
+  | 'removed__txHash'
+  | 'removed__timestamp'
   | 'offerType';
 
 export type CToken = {
@@ -5209,12 +5531,20 @@ export type CToken_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -5229,12 +5559,34 @@ export type CToken_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<CToken_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<CToken_filter>>>;
 };
 
 export type CToken_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'owner'
   | 'amount'
   | 'punkId'
@@ -5356,6 +5708,8 @@ export type Contract_filter = {
   imageHash_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Contract_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Contract_filter>>>;
 };
 
 export type Contract_orderBy =
@@ -5391,6 +5745,8 @@ export type EpnsNotificationCounter_filter = {
   totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<EpnsNotificationCounter_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<EpnsNotificationCounter_filter>>>;
 };
 
 export type EpnsNotificationCounter_orderBy =
@@ -5463,6 +5819,8 @@ export type EpnsPushNotification_filter = {
   notification_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<EpnsPushNotification_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<EpnsPushNotification_filter>>>;
 };
 
 export type EpnsPushNotification_orderBy =
@@ -5600,6 +5958,7 @@ export type Event_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   type?: InputMaybe<EventType>;
   type_not?: InputMaybe<EventType>;
   type_in?: InputMaybe<Array<EventType>>;
@@ -5622,12 +5981,20 @@ export type Event_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -5642,15 +6009,48 @@ export type Event_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Event_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Event_filter>>>;
 };
 
 export type Event_orderBy =
   | 'id'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'type'
   | 'logNumber'
   | 'blockNumber'
@@ -5811,6 +6211,8 @@ export type MetaData_filter = {
   traits_?: InputMaybe<Trait_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<MetaData_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<MetaData_filter>>>;
 };
 
 export type MetaData_orderBy =
@@ -5821,6 +6223,13 @@ export type MetaData_orderBy =
   | 'svg'
   | 'contractURI'
   | 'punk'
+  | 'punk__id'
+  | 'punk__tokenId'
+  | 'punk__wrapped'
+  | 'punk__numberOfTransfers'
+  | 'punk__numberOfSales'
+  | 'punk__totalAmountSpentOnPunk'
+  | 'punk__averageSalePrice'
   | 'traits';
 
 export type NFT = {
@@ -5925,6 +6334,7 @@ export type NFT_filter = {
   owner_not_ends_with?: InputMaybe<Scalars['String']>;
   owner_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
   owner_?: InputMaybe<Account_filter>;
+  events_?: InputMaybe<Event_filter>;
   currentAsk?: InputMaybe<Scalars['String']>;
   currentAsk_not?: InputMaybe<Scalars['String']>;
   currentAsk_gt?: InputMaybe<Scalars['String']>;
@@ -5969,18 +6379,45 @@ export type NFT_filter = {
   currentBid_?: InputMaybe<Bid_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<NFT_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<NFT_filter>>>;
 };
 
 export type NFT_orderBy =
   | 'id'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'numberOfTransfers'
   | 'numberOfSales'
   | 'tokenId'
   | 'owner'
+  | 'owner__id'
+  | 'owner__numberOfPunksOwned'
+  | 'owner__numberOfPunksAssigned'
+  | 'owner__numberOfTransfers'
+  | 'owner__numberOfSales'
+  | 'owner__numberOfPurchases'
+  | 'owner__totalSpent'
+  | 'owner__totalEarned'
+  | 'owner__averageAmountSpent'
+  | 'owner__accountUrl'
   | 'events'
   | 'currentAsk'
-  | 'currentBid';
+  | 'currentAsk__id'
+  | 'currentAsk__open'
+  | 'currentAsk__amount'
+  | 'currentAsk__offerType'
+  | 'currentBid'
+  | 'currentBid__id'
+  | 'currentBid__open'
+  | 'currentBid__amount'
+  | 'currentBid__offerType';
 
 export type Offer = {
   id: Scalars['ID'];
@@ -6065,6 +6502,7 @@ export type Offer_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   created?: InputMaybe<Scalars['String']>;
   created_not?: InputMaybe<Scalars['String']>;
   created_gt?: InputMaybe<Scalars['String']>;
@@ -6085,6 +6523,7 @@ export type Offer_filter = {
   created_ends_with_nocase?: InputMaybe<Scalars['String']>;
   created_not_ends_with?: InputMaybe<Scalars['String']>;
   created_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  created_?: InputMaybe<Event_filter>;
   removed?: InputMaybe<Scalars['String']>;
   removed_not?: InputMaybe<Scalars['String']>;
   removed_gt?: InputMaybe<Scalars['String']>;
@@ -6105,22 +6544,55 @@ export type Offer_filter = {
   removed_ends_with_nocase?: InputMaybe<Scalars['String']>;
   removed_not_ends_with?: InputMaybe<Scalars['String']>;
   removed_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  removed_?: InputMaybe<Event_filter>;
   offerType?: InputMaybe<OfferType>;
   offerType_not?: InputMaybe<OfferType>;
   offerType_in?: InputMaybe<Array<OfferType>>;
   offerType_not_in?: InputMaybe<Array<OfferType>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Offer_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Offer_filter>>>;
 };
 
 export type Offer_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'open'
   | 'amount'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'created'
+  | 'created__id'
+  | 'created__amount'
+  | 'created__type'
+  | 'created__logNumber'
+  | 'created__blockNumber'
+  | 'created__blockHash'
+  | 'created__txHash'
+  | 'created__timestamp'
   | 'removed'
+  | 'removed__id'
+  | 'removed__amount'
+  | 'removed__type'
+  | 'removed__logNumber'
+  | 'removed__blockNumber'
+  | 'removed__blockHash'
+  | 'removed__txHash'
+  | 'removed__timestamp'
   | 'offerType';
 
 export type Punk = NFT & {
@@ -6322,6 +6794,7 @@ export type Punk_filter = {
   wrapped_not?: InputMaybe<Scalars['Boolean']>;
   wrapped_in?: InputMaybe<Array<Scalars['Boolean']>>;
   wrapped_not_in?: InputMaybe<Array<Scalars['Boolean']>>;
+  events_?: InputMaybe<Event_filter>;
   currentAsk?: InputMaybe<Scalars['String']>;
   currentAsk_not?: InputMaybe<Scalars['String']>;
   currentAsk_gt?: InputMaybe<Scalars['String']>;
@@ -6482,27 +6955,122 @@ export type Punk_filter = {
   averageSalePrice_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Punk_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Punk_filter>>>;
 };
 
 export type Punk_orderBy =
   | 'id'
   | 'transferedTo'
+  | 'transferedTo__id'
+  | 'transferedTo__numberOfPunksOwned'
+  | 'transferedTo__numberOfPunksAssigned'
+  | 'transferedTo__numberOfTransfers'
+  | 'transferedTo__numberOfSales'
+  | 'transferedTo__numberOfPurchases'
+  | 'transferedTo__totalSpent'
+  | 'transferedTo__totalEarned'
+  | 'transferedTo__averageAmountSpent'
+  | 'transferedTo__accountUrl'
   | 'assignedTo'
+  | 'assignedTo__id'
+  | 'assignedTo__numberOfPunksOwned'
+  | 'assignedTo__numberOfPunksAssigned'
+  | 'assignedTo__numberOfTransfers'
+  | 'assignedTo__numberOfSales'
+  | 'assignedTo__numberOfPurchases'
+  | 'assignedTo__totalSpent'
+  | 'assignedTo__totalEarned'
+  | 'assignedTo__averageAmountSpent'
+  | 'assignedTo__accountUrl'
   | 'purchasedBy'
+  | 'purchasedBy__id'
+  | 'purchasedBy__numberOfPunksOwned'
+  | 'purchasedBy__numberOfPunksAssigned'
+  | 'purchasedBy__numberOfTransfers'
+  | 'purchasedBy__numberOfSales'
+  | 'purchasedBy__numberOfPurchases'
+  | 'purchasedBy__totalSpent'
+  | 'purchasedBy__totalEarned'
+  | 'purchasedBy__averageAmountSpent'
+  | 'purchasedBy__accountUrl'
   | 'metadata'
+  | 'metadata__id'
+  | 'metadata__tokenId'
+  | 'metadata__tokenURI'
+  | 'metadata__image'
+  | 'metadata__svg'
+  | 'metadata__contractURI'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'tokenId'
   | 'owner'
+  | 'owner__id'
+  | 'owner__numberOfPunksOwned'
+  | 'owner__numberOfPunksAssigned'
+  | 'owner__numberOfTransfers'
+  | 'owner__numberOfSales'
+  | 'owner__numberOfPurchases'
+  | 'owner__totalSpent'
+  | 'owner__totalEarned'
+  | 'owner__averageAmountSpent'
+  | 'owner__accountUrl'
   | 'wrapped'
   | 'events'
   | 'currentAsk'
+  | 'currentAsk__id'
+  | 'currentAsk__open'
+  | 'currentAsk__amount'
+  | 'currentAsk__offerType'
   | 'currentBid'
+  | 'currentBid__id'
+  | 'currentBid__open'
+  | 'currentBid__amount'
+  | 'currentBid__offerType'
   | 'currentAskCreated'
+  | 'currentAskCreated__id'
+  | 'currentAskCreated__amount'
+  | 'currentAskCreated__logNumber'
+  | 'currentAskCreated__type'
+  | 'currentAskCreated__blockNumber'
+  | 'currentAskCreated__blockHash'
+  | 'currentAskCreated__txHash'
+  | 'currentAskCreated__timestamp'
   | 'currentBidCreated'
+  | 'currentBidCreated__id'
+  | 'currentBidCreated__amount'
+  | 'currentBidCreated__logNumber'
+  | 'currentBidCreated__type'
+  | 'currentBidCreated__blockNumber'
+  | 'currentBidCreated__blockHash'
+  | 'currentBidCreated__txHash'
+  | 'currentBidCreated__timestamp'
   | 'numberOfTransfers'
   | 'numberOfSales'
   | 'currentAskRemoved'
+  | 'currentAskRemoved__id'
+  | 'currentAskRemoved__amount'
+  | 'currentAskRemoved__logNumber'
+  | 'currentAskRemoved__type'
+  | 'currentAskRemoved__blockNumber'
+  | 'currentAskRemoved__blockHash'
+  | 'currentAskRemoved__txHash'
+  | 'currentAskRemoved__timestamp'
   | 'currentBidRemoved'
+  | 'currentBidRemoved__id'
+  | 'currentBidRemoved__amount'
+  | 'currentBidRemoved__logNumber'
+  | 'currentBidRemoved__type'
+  | 'currentBidRemoved__blockNumber'
+  | 'currentBidRemoved__blockHash'
+  | 'currentBidRemoved__txHash'
+  | 'currentBidRemoved__timestamp'
   | 'totalAmountSpentOnPunk'
   | 'averageSalePrice';
 
@@ -6627,6 +7195,7 @@ export type Sale_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -6649,12 +7218,20 @@ export type Sale_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -6669,15 +7246,48 @@ export type Sale_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Sale_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Sale_filter>>>;
 };
 
 export type Sale_orderBy =
   | 'id'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -6731,6 +7341,8 @@ export type Trait_filter = {
   numberOfNfts_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Trait_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Trait_filter>>>;
 };
 
 export type Trait_orderBy =
@@ -6859,6 +7471,7 @@ export type Transfer_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -6881,12 +7494,20 @@ export type Transfer_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -6901,15 +7522,48 @@ export type Transfer_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Transfer_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Transfer_filter>>>;
 };
 
 export type Transfer_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -7036,6 +7690,7 @@ export type Unwrap_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -7058,12 +7713,20 @@ export type Unwrap_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -7078,15 +7741,48 @@ export type Unwrap_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Unwrap_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Unwrap_filter>>>;
 };
 
 export type Unwrap_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -7146,12 +7842,20 @@ export type UserProxy_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -7166,11 +7870,23 @@ export type UserProxy_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<UserProxy_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<UserProxy_filter>>>;
 };
 
 export type UserProxy_orderBy =
   | 'id'
   | 'user'
+  | 'user__id'
+  | 'user__numberOfPunksOwned'
+  | 'user__numberOfPunksAssigned'
+  | 'user__numberOfTransfers'
+  | 'user__numberOfSales'
+  | 'user__numberOfPurchases'
+  | 'user__totalSpent'
+  | 'user__totalEarned'
+  | 'user__averageAmountSpent'
+  | 'user__accountUrl'
   | 'blockNumber'
   | 'blockHash'
   | 'txHash'
@@ -7295,6 +8011,7 @@ export type Wrap_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -7317,12 +8034,20 @@ export type Wrap_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -7337,15 +8062,48 @@ export type Wrap_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Wrap_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Wrap_filter>>>;
 };
 
 export type Wrap_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -7663,6 +8421,22 @@ export type ResolversParentTypes = ResolversObject<{
   Wrap: Wrap;
   Wrap_filter: Wrap_filter;
 }>;
+
+export type entityDirectiveArgs = { };
+
+export type entityDirectiveResolver<Result, Parent, ContextType = MeshContext, Args = entityDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type subgraphIdDirectiveArgs = {
+  id: Scalars['String'];
+};
+
+export type subgraphIdDirectiveResolver<Result, Parent, ContextType = MeshContext, Args = subgraphIdDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type derivedFromDirectiveArgs = {
+  field: Scalars['String'];
+};
+
+export type derivedFromDirectiveResolver<Result, Parent, ContextType = MeshContext, Args = derivedFromDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type QueryResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
   delegateChange?: Resolver<Maybe<ResolversTypes['DelegateChange']>, ParentType, ContextType, RequireFields<QuerydelegateChangeArgs, 'id' | 'subgraphError'>>;
@@ -8412,6 +9186,11 @@ export type Resolvers<ContextType = MeshContext> = ResolversObject<{
   Wrap?: WrapResolvers<ContextType>;
 }>;
 
+export type DirectiveResolvers<ContextType = MeshContext> = ResolversObject<{
+  entity?: entityDirectiveResolver<any, any, ContextType>;
+  subgraphId?: subgraphIdDirectiveResolver<any, any, ContextType>;
+  derivedFrom?: derivedFromDirectiveResolver<any, any, ContextType>;
+}>;
 
 export type MeshContext = EnsGovernanceTypes.Context & BeaconDepositorsTypes.Context & CryptopunksTypes.Context & BaseMeshContext;
 
@@ -8601,7 +9380,9 @@ export type VotersPerProposalQuery = { proposal?: Maybe<(
     & { votes: Array<{ voter: Pick<Delegate, 'id'> }> }
   )> };
 
-export type PunkOwnersQueryVariables = Exact<{ [key: string]: never; }>;
+export type PunkOwnersQueryVariables = Exact<{
+  skip?: InputMaybe<Scalars['Int']>;
+}>;
 
 
 export type PunkOwnersQuery = { punks: Array<{ owner: Pick<Account, 'id'> }> };
@@ -8627,8 +9408,8 @@ export const VotersPerProposalDocument = gql`
 }
     ` as unknown as DocumentNode<VotersPerProposalQuery, VotersPerProposalQueryVariables>;
 export const PunkOwnersDocument = gql`
-    query PunkOwners {
-  punks {
+    query PunkOwners($skip: Int) {
+  punks(first: 1000, skip: $skip) {
     owner {
       id
     }

--- a/apis/query/src/lib/graph/.graphclient/index.ts
+++ b/apis/query/src/lib/graph/.graphclient/index.ts
@@ -45,6 +45,16 @@ export type Scalars = {
 };
 
 export type Query = {
+  aggregation?: Maybe<Aggregation>;
+  aggregations: Array<Aggregation>;
+  depositor?: Maybe<Depositor>;
+  depositors: Array<Depositor>;
+  dailyDeposit?: Maybe<DailyDeposit>;
+  dailyDeposits: Array<DailyDeposit>;
+  deposit?: Maybe<Deposit>;
+  deposits: Array<Deposit>;
+  /** Access to subgraph metadata */
+  _meta?: Maybe<_Meta_>;
   delegateChange?: Maybe<DelegateChange>;
   delegateChanges: Array<DelegateChange>;
   delegateVotingPowerChange?: Maybe<DelegateVotingPowerChange>;
@@ -65,16 +75,6 @@ export type Query = {
   tokenDailySnapshots: Array<TokenDailySnapshot>;
   voteDailySnapshot?: Maybe<VoteDailySnapshot>;
   voteDailySnapshots: Array<VoteDailySnapshot>;
-  /** Access to subgraph metadata */
-  _meta?: Maybe<_Meta_>;
-  aggregation?: Maybe<Aggregation>;
-  aggregations: Array<Aggregation>;
-  depositor?: Maybe<Depositor>;
-  depositors: Array<Depositor>;
-  dailyDeposit?: Maybe<DailyDeposit>;
-  dailyDeposits: Array<DailyDeposit>;
-  deposit?: Maybe<Deposit>;
-  deposits: Array<Deposit>;
   account?: Maybe<Account>;
   accounts: Array<Account>;
   punk?: Maybe<Punk>;
@@ -121,6 +121,83 @@ export type Query = {
   events: Array<Event>;
   offer?: Maybe<Offer>;
   offers: Array<Offer>;
+};
+
+
+export type QueryaggregationArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryaggregationsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Aggregation_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Aggregation_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydepositorArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydepositorsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Depositor_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Depositor_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydailyDepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydailyDepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<DailyDeposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<DailyDeposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Deposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Deposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type Query_metaArgs = {
+  block?: InputMaybe<Block_height>;
 };
 
 
@@ -299,83 +376,6 @@ export type QueryvoteDailySnapshotsArgs = {
   orderBy?: InputMaybe<VoteDailySnapshot_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<VoteDailySnapshot_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type Query_metaArgs = {
-  block?: InputMaybe<Block_height>;
-};
-
-
-export type QueryaggregationArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QueryaggregationsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Aggregation_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Aggregation_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydepositorArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydepositorsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Depositor_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Depositor_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydailyDepositArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydailyDepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<DailyDeposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<DailyDeposit_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydepositArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Deposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Deposit_filter>;
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
@@ -795,6 +795,16 @@ export type QueryoffersArgs = {
 };
 
 export type Subscription = {
+  aggregation?: Maybe<Aggregation>;
+  aggregations: Array<Aggregation>;
+  depositor?: Maybe<Depositor>;
+  depositors: Array<Depositor>;
+  dailyDeposit?: Maybe<DailyDeposit>;
+  dailyDeposits: Array<DailyDeposit>;
+  deposit?: Maybe<Deposit>;
+  deposits: Array<Deposit>;
+  /** Access to subgraph metadata */
+  _meta?: Maybe<_Meta_>;
   delegateChange?: Maybe<DelegateChange>;
   delegateChanges: Array<DelegateChange>;
   delegateVotingPowerChange?: Maybe<DelegateVotingPowerChange>;
@@ -815,16 +825,6 @@ export type Subscription = {
   tokenDailySnapshots: Array<TokenDailySnapshot>;
   voteDailySnapshot?: Maybe<VoteDailySnapshot>;
   voteDailySnapshots: Array<VoteDailySnapshot>;
-  /** Access to subgraph metadata */
-  _meta?: Maybe<_Meta_>;
-  aggregation?: Maybe<Aggregation>;
-  aggregations: Array<Aggregation>;
-  depositor?: Maybe<Depositor>;
-  depositors: Array<Depositor>;
-  dailyDeposit?: Maybe<DailyDeposit>;
-  dailyDeposits: Array<DailyDeposit>;
-  deposit?: Maybe<Deposit>;
-  deposits: Array<Deposit>;
   account?: Maybe<Account>;
   accounts: Array<Account>;
   punk?: Maybe<Punk>;
@@ -871,6 +871,83 @@ export type Subscription = {
   events: Array<Event>;
   offer?: Maybe<Offer>;
   offers: Array<Offer>;
+};
+
+
+export type SubscriptionaggregationArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionaggregationsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Aggregation_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Aggregation_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondepositorArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondepositorsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Depositor_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Depositor_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondailyDepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondailyDepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<DailyDeposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<DailyDeposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Deposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Deposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type Subscription_metaArgs = {
+  block?: InputMaybe<Block_height>;
 };
 
 
@@ -1049,83 +1126,6 @@ export type SubscriptionvoteDailySnapshotsArgs = {
   orderBy?: InputMaybe<VoteDailySnapshot_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<VoteDailySnapshot_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type Subscription_metaArgs = {
-  block?: InputMaybe<Block_height>;
-};
-
-
-export type SubscriptionaggregationArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptionaggregationsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Aggregation_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Aggregation_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondepositorArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondepositorsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Depositor_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Depositor_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondailyDepositArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondailyDepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<DailyDeposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<DailyDeposit_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondepositArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Deposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Deposit_filter>;
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
@@ -1544,6 +1544,58 @@ export type SubscriptionoffersArgs = {
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+export type Aggregation = {
+  id: Scalars['ID'];
+  totalDeposits?: Maybe<Scalars['BigInt']>;
+  totalDepositors?: Maybe<Scalars['BigInt']>;
+  totalAmountDeposited?: Maybe<Scalars['BigInt']>;
+};
+
+export type Aggregation_filter = {
+  id?: InputMaybe<Scalars['ID']>;
+  id_not?: InputMaybe<Scalars['ID']>;
+  id_gt?: InputMaybe<Scalars['ID']>;
+  id_lt?: InputMaybe<Scalars['ID']>;
+  id_gte?: InputMaybe<Scalars['ID']>;
+  id_lte?: InputMaybe<Scalars['ID']>;
+  id_in?: InputMaybe<Array<Scalars['ID']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  totalDeposits?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_not?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_gt?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_lt?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_gte?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_lte?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalDeposits_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalDepositors?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_not?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_gt?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_lt?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_gte?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_lte?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalDepositors_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalAmountDeposited?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
+};
+
+export type Aggregation_orderBy =
+  | 'id'
+  | 'totalDeposits'
+  | 'totalDepositors'
+  | 'totalAmountDeposited';
+
 export type BlockChangedFilter = {
   number_gte: Scalars['Int'];
 };
@@ -1553,6 +1605,252 @@ export type Block_height = {
   number?: InputMaybe<Scalars['Int']>;
   number_gte?: InputMaybe<Scalars['Int']>;
 };
+
+export type DailyDeposit = {
+  id: Scalars['ID'];
+  dailyAmountDeposited?: Maybe<Scalars['BigInt']>;
+  dailyDepositCount?: Maybe<Scalars['BigInt']>;
+};
+
+export type DailyDeposit_filter = {
+  id?: InputMaybe<Scalars['ID']>;
+  id_not?: InputMaybe<Scalars['ID']>;
+  id_gt?: InputMaybe<Scalars['ID']>;
+  id_lt?: InputMaybe<Scalars['ID']>;
+  id_gte?: InputMaybe<Scalars['ID']>;
+  id_lte?: InputMaybe<Scalars['ID']>;
+  id_in?: InputMaybe<Array<Scalars['ID']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  dailyAmountDeposited?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  dailyAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  dailyDepositCount?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_not?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_gt?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_lt?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_gte?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_lte?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  dailyDepositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
+};
+
+export type DailyDeposit_orderBy =
+  | 'id'
+  | 'dailyAmountDeposited'
+  | 'dailyDepositCount';
+
+export type Deposit = {
+  id: Scalars['ID'];
+  dayID: Scalars['String'];
+  depositor?: Maybe<Depositor>;
+  pubkey: Scalars['Bytes'];
+  withdrawal_credentials: Scalars['Bytes'];
+  amount: Scalars['BigInt'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type Deposit_filter = {
+  id?: InputMaybe<Scalars['ID']>;
+  id_not?: InputMaybe<Scalars['ID']>;
+  id_gt?: InputMaybe<Scalars['ID']>;
+  id_lt?: InputMaybe<Scalars['ID']>;
+  id_gte?: InputMaybe<Scalars['ID']>;
+  id_lte?: InputMaybe<Scalars['ID']>;
+  id_in?: InputMaybe<Array<Scalars['ID']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  dayID?: InputMaybe<Scalars['String']>;
+  dayID_not?: InputMaybe<Scalars['String']>;
+  dayID_gt?: InputMaybe<Scalars['String']>;
+  dayID_lt?: InputMaybe<Scalars['String']>;
+  dayID_gte?: InputMaybe<Scalars['String']>;
+  dayID_lte?: InputMaybe<Scalars['String']>;
+  dayID_in?: InputMaybe<Array<Scalars['String']>>;
+  dayID_not_in?: InputMaybe<Array<Scalars['String']>>;
+  dayID_contains?: InputMaybe<Scalars['String']>;
+  dayID_contains_nocase?: InputMaybe<Scalars['String']>;
+  dayID_not_contains?: InputMaybe<Scalars['String']>;
+  dayID_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  dayID_starts_with?: InputMaybe<Scalars['String']>;
+  dayID_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  dayID_not_starts_with?: InputMaybe<Scalars['String']>;
+  dayID_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  dayID_ends_with?: InputMaybe<Scalars['String']>;
+  dayID_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  dayID_not_ends_with?: InputMaybe<Scalars['String']>;
+  dayID_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor?: InputMaybe<Scalars['String']>;
+  depositor_not?: InputMaybe<Scalars['String']>;
+  depositor_gt?: InputMaybe<Scalars['String']>;
+  depositor_lt?: InputMaybe<Scalars['String']>;
+  depositor_gte?: InputMaybe<Scalars['String']>;
+  depositor_lte?: InputMaybe<Scalars['String']>;
+  depositor_in?: InputMaybe<Array<Scalars['String']>>;
+  depositor_not_in?: InputMaybe<Array<Scalars['String']>>;
+  depositor_contains?: InputMaybe<Scalars['String']>;
+  depositor_contains_nocase?: InputMaybe<Scalars['String']>;
+  depositor_not_contains?: InputMaybe<Scalars['String']>;
+  depositor_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  depositor_starts_with?: InputMaybe<Scalars['String']>;
+  depositor_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor_not_starts_with?: InputMaybe<Scalars['String']>;
+  depositor_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor_ends_with?: InputMaybe<Scalars['String']>;
+  depositor_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor_not_ends_with?: InputMaybe<Scalars['String']>;
+  depositor_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor_?: InputMaybe<Depositor_filter>;
+  pubkey?: InputMaybe<Scalars['Bytes']>;
+  pubkey_not?: InputMaybe<Scalars['Bytes']>;
+  pubkey_gt?: InputMaybe<Scalars['Bytes']>;
+  pubkey_lt?: InputMaybe<Scalars['Bytes']>;
+  pubkey_gte?: InputMaybe<Scalars['Bytes']>;
+  pubkey_lte?: InputMaybe<Scalars['Bytes']>;
+  pubkey_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  pubkey_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  pubkey_contains?: InputMaybe<Scalars['Bytes']>;
+  pubkey_not_contains?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_not?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_gt?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_lt?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_gte?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_lte?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  withdrawal_credentials_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  withdrawal_credentials_contains?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_not_contains?: InputMaybe<Scalars['Bytes']>;
+  amount?: InputMaybe<Scalars['BigInt']>;
+  amount_not?: InputMaybe<Scalars['BigInt']>;
+  amount_gt?: InputMaybe<Scalars['BigInt']>;
+  amount_lt?: InputMaybe<Scalars['BigInt']>;
+  amount_gte?: InputMaybe<Scalars['BigInt']>;
+  amount_lte?: InputMaybe<Scalars['BigInt']>;
+  amount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  amount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
+};
+
+export type Deposit_orderBy =
+  | 'id'
+  | 'dayID'
+  | 'depositor'
+  | 'depositor__id'
+  | 'depositor__totalAmountDeposited'
+  | 'depositor__depositCount'
+  | 'pubkey'
+  | 'withdrawal_credentials'
+  | 'amount'
+  | 'timestamp';
+
+export type Depositor = {
+  id: Scalars['ID'];
+  totalAmountDeposited?: Maybe<Scalars['BigInt']>;
+  depositCount?: Maybe<Scalars['BigInt']>;
+  deposits?: Maybe<Array<Deposit>>;
+};
+
+
+export type DepositordepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Deposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Deposit_filter>;
+};
+
+export type Depositor_filter = {
+  id?: InputMaybe<Scalars['ID']>;
+  id_not?: InputMaybe<Scalars['ID']>;
+  id_gt?: InputMaybe<Scalars['ID']>;
+  id_lt?: InputMaybe<Scalars['ID']>;
+  id_gte?: InputMaybe<Scalars['ID']>;
+  id_lte?: InputMaybe<Scalars['ID']>;
+  id_in?: InputMaybe<Array<Scalars['ID']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  totalAmountDeposited?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  depositCount?: InputMaybe<Scalars['BigInt']>;
+  depositCount_not?: InputMaybe<Scalars['BigInt']>;
+  depositCount_gt?: InputMaybe<Scalars['BigInt']>;
+  depositCount_lt?: InputMaybe<Scalars['BigInt']>;
+  depositCount_gte?: InputMaybe<Scalars['BigInt']>;
+  depositCount_lte?: InputMaybe<Scalars['BigInt']>;
+  depositCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  depositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposits_?: InputMaybe<Deposit_filter>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
+};
+
+export type Depositor_orderBy =
+  | 'id'
+  | 'totalAmountDeposited'
+  | 'depositCount'
+  | 'deposits';
+
+/** Defines the order direction, either ascending or descending */
+export type OrderDirection =
+  | 'asc'
+  | 'desc';
+
+export type _Block_ = {
+  /** The hash of the block */
+  hash?: Maybe<Scalars['Bytes']>;
+  /** The block number */
+  number: Scalars['Int'];
+  /** Integer representation of the timestamp stored in blocks for the chain */
+  timestamp?: Maybe<Scalars['Int']>;
+};
+
+/** The type for the top-level _meta field */
+export type _Meta_ = {
+  /**
+   * Information about a specific subgraph block. The hash of the block
+   * will be null if the _meta field has a block constraint that asks for
+   * a block number. It will be filled if the _meta field has no block constraint
+   * and therefore asks for the latest  block
+   *
+   */
+  block: _Block_;
+  /** The deployment ID */
+  deployment: Scalars['String'];
+  /** If `true`, the subgraph encountered indexing errors at some past block */
+  hasIndexingErrors: Scalars['Boolean'];
+};
+
+export type _SubgraphErrorPolicy_ =
+  /** Data will be returned even if the subgraph has indexing errors */
+  | 'allow'
+  /** If the subgraph has indexing errors, data will be omitted. The default. */
+  | 'deny';
 
 export type Delegate = {
   /** A Delegate is any address that has been delegated with voting tokens by a token holder, id is the blockchain address of said delegate */
@@ -2351,11 +2649,6 @@ export type Governance_orderBy =
   | 'proposalsQueued'
   | 'proposalsExecuted'
   | 'proposalsCanceled';
-
-/** Defines the order direction, either ascending or descending */
-export type OrderDirection =
-  | 'asc'
-  | 'desc';
 
 export type Proposal = {
   /** Internal proposal ID, in this implementation it seems to be a autoincremental id */
@@ -3296,299 +3589,6 @@ export type Vote_orderBy =
   | 'block'
   | 'blockTime'
   | 'txnHash';
-
-export type _Block_ = {
-  /** The hash of the block */
-  hash?: Maybe<Scalars['Bytes']>;
-  /** The block number */
-  number: Scalars['Int'];
-  /** Integer representation of the timestamp stored in blocks for the chain */
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** The type for the top-level _meta field */
-export type _Meta_ = {
-  /**
-   * Information about a specific subgraph block. The hash of the block
-   * will be null if the _meta field has a block constraint that asks for
-   * a block number. It will be filled if the _meta field has no block constraint
-   * and therefore asks for the latest  block
-   *
-   */
-  block: _Block_;
-  /** The deployment ID */
-  deployment: Scalars['String'];
-  /** If `true`, the subgraph encountered indexing errors at some past block */
-  hasIndexingErrors: Scalars['Boolean'];
-};
-
-export type _SubgraphErrorPolicy_ =
-  /** Data will be returned even if the subgraph has indexing errors */
-  | 'allow'
-  /** If the subgraph has indexing errors, data will be omitted. The default. */
-  | 'deny';
-
-export type Aggregation = {
-  id: Scalars['ID'];
-  totalDeposits?: Maybe<Scalars['BigInt']>;
-  totalDepositors?: Maybe<Scalars['BigInt']>;
-  totalAmountDeposited?: Maybe<Scalars['BigInt']>;
-};
-
-export type Aggregation_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  totalDeposits?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_not?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_gt?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_lt?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_gte?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_lte?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalDeposits_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalDepositors?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_not?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_gt?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_lt?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_gte?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_lte?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalDepositors_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalAmountDeposited?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
-};
-
-export type Aggregation_orderBy =
-  | 'id'
-  | 'totalDeposits'
-  | 'totalDepositors'
-  | 'totalAmountDeposited';
-
-export type DailyDeposit = {
-  id: Scalars['ID'];
-  dailyAmountDeposited?: Maybe<Scalars['BigInt']>;
-  dailyDepositCount?: Maybe<Scalars['BigInt']>;
-};
-
-export type DailyDeposit_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  dailyAmountDeposited?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  dailyAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  dailyDepositCount?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_not?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_gt?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_lt?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_gte?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_lte?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  dailyDepositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
-};
-
-export type DailyDeposit_orderBy =
-  | 'id'
-  | 'dailyAmountDeposited'
-  | 'dailyDepositCount';
-
-export type Deposit = {
-  id: Scalars['ID'];
-  dayID: Scalars['String'];
-  depositor?: Maybe<Depositor>;
-  pubkey: Scalars['Bytes'];
-  withdrawal_credentials: Scalars['Bytes'];
-  amount: Scalars['BigInt'];
-  timestamp: Scalars['BigInt'];
-};
-
-export type Deposit_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  dayID?: InputMaybe<Scalars['String']>;
-  dayID_not?: InputMaybe<Scalars['String']>;
-  dayID_gt?: InputMaybe<Scalars['String']>;
-  dayID_lt?: InputMaybe<Scalars['String']>;
-  dayID_gte?: InputMaybe<Scalars['String']>;
-  dayID_lte?: InputMaybe<Scalars['String']>;
-  dayID_in?: InputMaybe<Array<Scalars['String']>>;
-  dayID_not_in?: InputMaybe<Array<Scalars['String']>>;
-  dayID_contains?: InputMaybe<Scalars['String']>;
-  dayID_contains_nocase?: InputMaybe<Scalars['String']>;
-  dayID_not_contains?: InputMaybe<Scalars['String']>;
-  dayID_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  dayID_starts_with?: InputMaybe<Scalars['String']>;
-  dayID_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  dayID_not_starts_with?: InputMaybe<Scalars['String']>;
-  dayID_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  dayID_ends_with?: InputMaybe<Scalars['String']>;
-  dayID_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  dayID_not_ends_with?: InputMaybe<Scalars['String']>;
-  dayID_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor?: InputMaybe<Scalars['String']>;
-  depositor_not?: InputMaybe<Scalars['String']>;
-  depositor_gt?: InputMaybe<Scalars['String']>;
-  depositor_lt?: InputMaybe<Scalars['String']>;
-  depositor_gte?: InputMaybe<Scalars['String']>;
-  depositor_lte?: InputMaybe<Scalars['String']>;
-  depositor_in?: InputMaybe<Array<Scalars['String']>>;
-  depositor_not_in?: InputMaybe<Array<Scalars['String']>>;
-  depositor_contains?: InputMaybe<Scalars['String']>;
-  depositor_contains_nocase?: InputMaybe<Scalars['String']>;
-  depositor_not_contains?: InputMaybe<Scalars['String']>;
-  depositor_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  depositor_starts_with?: InputMaybe<Scalars['String']>;
-  depositor_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor_not_starts_with?: InputMaybe<Scalars['String']>;
-  depositor_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor_ends_with?: InputMaybe<Scalars['String']>;
-  depositor_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor_not_ends_with?: InputMaybe<Scalars['String']>;
-  depositor_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor_?: InputMaybe<Depositor_filter>;
-  pubkey?: InputMaybe<Scalars['Bytes']>;
-  pubkey_not?: InputMaybe<Scalars['Bytes']>;
-  pubkey_gt?: InputMaybe<Scalars['Bytes']>;
-  pubkey_lt?: InputMaybe<Scalars['Bytes']>;
-  pubkey_gte?: InputMaybe<Scalars['Bytes']>;
-  pubkey_lte?: InputMaybe<Scalars['Bytes']>;
-  pubkey_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  pubkey_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  pubkey_contains?: InputMaybe<Scalars['Bytes']>;
-  pubkey_not_contains?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_not?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_gt?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_lt?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_gte?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_lte?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  withdrawal_credentials_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  withdrawal_credentials_contains?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_not_contains?: InputMaybe<Scalars['Bytes']>;
-  amount?: InputMaybe<Scalars['BigInt']>;
-  amount_not?: InputMaybe<Scalars['BigInt']>;
-  amount_gt?: InputMaybe<Scalars['BigInt']>;
-  amount_lt?: InputMaybe<Scalars['BigInt']>;
-  amount_gte?: InputMaybe<Scalars['BigInt']>;
-  amount_lte?: InputMaybe<Scalars['BigInt']>;
-  amount_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  amount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  timestamp?: InputMaybe<Scalars['BigInt']>;
-  timestamp_not?: InputMaybe<Scalars['BigInt']>;
-  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
-  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
-  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
-  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
-  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
-};
-
-export type Deposit_orderBy =
-  | 'id'
-  | 'dayID'
-  | 'depositor'
-  | 'depositor__id'
-  | 'depositor__totalAmountDeposited'
-  | 'depositor__depositCount'
-  | 'pubkey'
-  | 'withdrawal_credentials'
-  | 'amount'
-  | 'timestamp';
-
-export type Depositor = {
-  id: Scalars['ID'];
-  totalAmountDeposited?: Maybe<Scalars['BigInt']>;
-  depositCount?: Maybe<Scalars['BigInt']>;
-  deposits?: Maybe<Array<Deposit>>;
-};
-
-
-export type DepositordepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Deposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Deposit_filter>;
-};
-
-export type Depositor_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  totalAmountDeposited?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  depositCount?: InputMaybe<Scalars['BigInt']>;
-  depositCount_not?: InputMaybe<Scalars['BigInt']>;
-  depositCount_gt?: InputMaybe<Scalars['BigInt']>;
-  depositCount_lt?: InputMaybe<Scalars['BigInt']>;
-  depositCount_gte?: InputMaybe<Scalars['BigInt']>;
-  depositCount_lte?: InputMaybe<Scalars['BigInt']>;
-  depositCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  depositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  deposits_?: InputMaybe<Deposit_filter>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
-};
-
-export type Depositor_orderBy =
-  | 'id'
-  | 'totalAmountDeposited'
-  | 'depositCount'
-  | 'deposits';
 
 export type Account = {
   /** Ethereum Address */
@@ -8197,12 +8197,32 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversTypes = ResolversObject<{
   Query: ResolverTypeWrapper<{}>;
   Subscription: ResolverTypeWrapper<{}>;
+  Aggregation: ResolverTypeWrapper<Aggregation>;
+  Aggregation_filter: Aggregation_filter;
+  Aggregation_orderBy: Aggregation_orderBy;
   BigDecimal: ResolverTypeWrapper<Scalars['BigDecimal']>;
   BigInt: ResolverTypeWrapper<Scalars['BigInt']>;
   BlockChangedFilter: BlockChangedFilter;
   Block_height: Block_height;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   Bytes: ResolverTypeWrapper<Scalars['Bytes']>;
+  DailyDeposit: ResolverTypeWrapper<DailyDeposit>;
+  DailyDeposit_filter: DailyDeposit_filter;
+  DailyDeposit_orderBy: DailyDeposit_orderBy;
+  Deposit: ResolverTypeWrapper<Deposit>;
+  Deposit_filter: Deposit_filter;
+  Deposit_orderBy: Deposit_orderBy;
+  Depositor: ResolverTypeWrapper<Depositor>;
+  Depositor_filter: Depositor_filter;
+  Depositor_orderBy: Depositor_orderBy;
+  Float: ResolverTypeWrapper<Scalars['Float']>;
+  ID: ResolverTypeWrapper<Scalars['ID']>;
+  Int: ResolverTypeWrapper<Scalars['Int']>;
+  OrderDirection: OrderDirection;
+  String: ResolverTypeWrapper<Scalars['String']>;
+  _Block_: ResolverTypeWrapper<_Block_>;
+  _Meta_: ResolverTypeWrapper<_Meta_>;
+  _SubgraphErrorPolicy_: _SubgraphErrorPolicy_;
   Delegate: ResolverTypeWrapper<Delegate>;
   DelegateChange: ResolverTypeWrapper<DelegateChange>;
   DelegateChange_filter: DelegateChange_filter;
@@ -8212,7 +8232,6 @@ export type ResolversTypes = ResolversObject<{
   DelegateVotingPowerChange_orderBy: DelegateVotingPowerChange_orderBy;
   Delegate_filter: Delegate_filter;
   Delegate_orderBy: Delegate_orderBy;
-  Float: ResolverTypeWrapper<Scalars['Float']>;
   Governance: ResolverTypeWrapper<Governance>;
   GovernanceFramework: ResolverTypeWrapper<GovernanceFramework>;
   GovernanceFrameworkType: GovernanceFrameworkType;
@@ -8220,14 +8239,10 @@ export type ResolversTypes = ResolversObject<{
   GovernanceFramework_orderBy: GovernanceFramework_orderBy;
   Governance_filter: Governance_filter;
   Governance_orderBy: Governance_orderBy;
-  ID: ResolverTypeWrapper<Scalars['ID']>;
-  Int: ResolverTypeWrapper<Scalars['Int']>;
-  OrderDirection: OrderDirection;
   Proposal: ResolverTypeWrapper<Proposal>;
   ProposalState: ProposalState;
   Proposal_filter: Proposal_filter;
   Proposal_orderBy: Proposal_orderBy;
-  String: ResolverTypeWrapper<Scalars['String']>;
   TokenDailySnapshot: ResolverTypeWrapper<TokenDailySnapshot>;
   TokenDailySnapshot_filter: TokenDailySnapshot_filter;
   TokenDailySnapshot_orderBy: TokenDailySnapshot_orderBy;
@@ -8241,21 +8256,6 @@ export type ResolversTypes = ResolversObject<{
   VoteDailySnapshot_orderBy: VoteDailySnapshot_orderBy;
   Vote_filter: Vote_filter;
   Vote_orderBy: Vote_orderBy;
-  _Block_: ResolverTypeWrapper<_Block_>;
-  _Meta_: ResolverTypeWrapper<_Meta_>;
-  _SubgraphErrorPolicy_: _SubgraphErrorPolicy_;
-  Aggregation: ResolverTypeWrapper<Aggregation>;
-  Aggregation_filter: Aggregation_filter;
-  Aggregation_orderBy: Aggregation_orderBy;
-  DailyDeposit: ResolverTypeWrapper<DailyDeposit>;
-  DailyDeposit_filter: DailyDeposit_filter;
-  DailyDeposit_orderBy: DailyDeposit_orderBy;
-  Deposit: ResolverTypeWrapper<Deposit>;
-  Deposit_filter: Deposit_filter;
-  Deposit_orderBy: Deposit_orderBy;
-  Depositor: ResolverTypeWrapper<Depositor>;
-  Depositor_filter: Depositor_filter;
-  Depositor_orderBy: Depositor_orderBy;
   Account: ResolverTypeWrapper<Account>;
   Account_filter: Account_filter;
   Account_orderBy: Account_orderBy;
@@ -8334,28 +8334,38 @@ export type ResolversTypes = ResolversObject<{
 export type ResolversParentTypes = ResolversObject<{
   Query: {};
   Subscription: {};
+  Aggregation: Aggregation;
+  Aggregation_filter: Aggregation_filter;
   BigDecimal: Scalars['BigDecimal'];
   BigInt: Scalars['BigInt'];
   BlockChangedFilter: BlockChangedFilter;
   Block_height: Block_height;
   Boolean: Scalars['Boolean'];
   Bytes: Scalars['Bytes'];
+  DailyDeposit: DailyDeposit;
+  DailyDeposit_filter: DailyDeposit_filter;
+  Deposit: Deposit;
+  Deposit_filter: Deposit_filter;
+  Depositor: Depositor;
+  Depositor_filter: Depositor_filter;
+  Float: Scalars['Float'];
+  ID: Scalars['ID'];
+  Int: Scalars['Int'];
+  String: Scalars['String'];
+  _Block_: _Block_;
+  _Meta_: _Meta_;
   Delegate: Delegate;
   DelegateChange: DelegateChange;
   DelegateChange_filter: DelegateChange_filter;
   DelegateVotingPowerChange: DelegateVotingPowerChange;
   DelegateVotingPowerChange_filter: DelegateVotingPowerChange_filter;
   Delegate_filter: Delegate_filter;
-  Float: Scalars['Float'];
   Governance: Governance;
   GovernanceFramework: GovernanceFramework;
   GovernanceFramework_filter: GovernanceFramework_filter;
   Governance_filter: Governance_filter;
-  ID: Scalars['ID'];
-  Int: Scalars['Int'];
   Proposal: Proposal;
   Proposal_filter: Proposal_filter;
-  String: Scalars['String'];
   TokenDailySnapshot: TokenDailySnapshot;
   TokenDailySnapshot_filter: TokenDailySnapshot_filter;
   TokenHolder: TokenHolder;
@@ -8364,16 +8374,6 @@ export type ResolversParentTypes = ResolversObject<{
   VoteDailySnapshot: VoteDailySnapshot;
   VoteDailySnapshot_filter: VoteDailySnapshot_filter;
   Vote_filter: Vote_filter;
-  _Block_: _Block_;
-  _Meta_: _Meta_;
-  Aggregation: Aggregation;
-  Aggregation_filter: Aggregation_filter;
-  DailyDeposit: DailyDeposit;
-  DailyDeposit_filter: DailyDeposit_filter;
-  Deposit: Deposit;
-  Deposit_filter: Deposit_filter;
-  Depositor: Depositor;
-  Depositor_filter: Depositor_filter;
   Account: Account;
   Account_filter: Account_filter;
   Ask: Ask;
@@ -8439,6 +8439,15 @@ export type derivedFromDirectiveArgs = {
 export type derivedFromDirectiveResolver<Result, Parent, ContextType = MeshContext, Args = derivedFromDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type QueryResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
+  aggregation?: Resolver<Maybe<ResolversTypes['Aggregation']>, ParentType, ContextType, RequireFields<QueryaggregationArgs, 'id' | 'subgraphError'>>;
+  aggregations?: Resolver<Array<ResolversTypes['Aggregation']>, ParentType, ContextType, RequireFields<QueryaggregationsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  depositor?: Resolver<Maybe<ResolversTypes['Depositor']>, ParentType, ContextType, RequireFields<QuerydepositorArgs, 'id' | 'subgraphError'>>;
+  depositors?: Resolver<Array<ResolversTypes['Depositor']>, ParentType, ContextType, RequireFields<QuerydepositorsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  dailyDeposit?: Resolver<Maybe<ResolversTypes['DailyDeposit']>, ParentType, ContextType, RequireFields<QuerydailyDepositArgs, 'id' | 'subgraphError'>>;
+  dailyDeposits?: Resolver<Array<ResolversTypes['DailyDeposit']>, ParentType, ContextType, RequireFields<QuerydailyDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  deposit?: Resolver<Maybe<ResolversTypes['Deposit']>, ParentType, ContextType, RequireFields<QuerydepositArgs, 'id' | 'subgraphError'>>;
+  deposits?: Resolver<Array<ResolversTypes['Deposit']>, ParentType, ContextType, RequireFields<QuerydepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  _meta?: Resolver<Maybe<ResolversTypes['_Meta_']>, ParentType, ContextType, Partial<Query_metaArgs>>;
   delegateChange?: Resolver<Maybe<ResolversTypes['DelegateChange']>, ParentType, ContextType, RequireFields<QuerydelegateChangeArgs, 'id' | 'subgraphError'>>;
   delegateChanges?: Resolver<Array<ResolversTypes['DelegateChange']>, ParentType, ContextType, RequireFields<QuerydelegateChangesArgs, 'skip' | 'first' | 'subgraphError'>>;
   delegateVotingPowerChange?: Resolver<Maybe<ResolversTypes['DelegateVotingPowerChange']>, ParentType, ContextType, RequireFields<QuerydelegateVotingPowerChangeArgs, 'id' | 'subgraphError'>>;
@@ -8459,15 +8468,6 @@ export type QueryResolvers<ContextType = MeshContext, ParentType extends Resolve
   tokenDailySnapshots?: Resolver<Array<ResolversTypes['TokenDailySnapshot']>, ParentType, ContextType, RequireFields<QuerytokenDailySnapshotsArgs, 'skip' | 'first' | 'subgraphError'>>;
   voteDailySnapshot?: Resolver<Maybe<ResolversTypes['VoteDailySnapshot']>, ParentType, ContextType, RequireFields<QueryvoteDailySnapshotArgs, 'id' | 'subgraphError'>>;
   voteDailySnapshots?: Resolver<Array<ResolversTypes['VoteDailySnapshot']>, ParentType, ContextType, RequireFields<QueryvoteDailySnapshotsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  _meta?: Resolver<Maybe<ResolversTypes['_Meta_']>, ParentType, ContextType, Partial<Query_metaArgs>>;
-  aggregation?: Resolver<Maybe<ResolversTypes['Aggregation']>, ParentType, ContextType, RequireFields<QueryaggregationArgs, 'id' | 'subgraphError'>>;
-  aggregations?: Resolver<Array<ResolversTypes['Aggregation']>, ParentType, ContextType, RequireFields<QueryaggregationsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  depositor?: Resolver<Maybe<ResolversTypes['Depositor']>, ParentType, ContextType, RequireFields<QuerydepositorArgs, 'id' | 'subgraphError'>>;
-  depositors?: Resolver<Array<ResolversTypes['Depositor']>, ParentType, ContextType, RequireFields<QuerydepositorsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  dailyDeposit?: Resolver<Maybe<ResolversTypes['DailyDeposit']>, ParentType, ContextType, RequireFields<QuerydailyDepositArgs, 'id' | 'subgraphError'>>;
-  dailyDeposits?: Resolver<Array<ResolversTypes['DailyDeposit']>, ParentType, ContextType, RequireFields<QuerydailyDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  deposit?: Resolver<Maybe<ResolversTypes['Deposit']>, ParentType, ContextType, RequireFields<QuerydepositArgs, 'id' | 'subgraphError'>>;
-  deposits?: Resolver<Array<ResolversTypes['Deposit']>, ParentType, ContextType, RequireFields<QuerydepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
   account?: Resolver<Maybe<ResolversTypes['Account']>, ParentType, ContextType, RequireFields<QueryaccountArgs, 'id' | 'subgraphError'>>;
   accounts?: Resolver<Array<ResolversTypes['Account']>, ParentType, ContextType, RequireFields<QueryaccountsArgs, 'skip' | 'first' | 'subgraphError'>>;
   punk?: Resolver<Maybe<ResolversTypes['Punk']>, ParentType, ContextType, RequireFields<QuerypunkArgs, 'id' | 'subgraphError'>>;
@@ -8517,6 +8517,15 @@ export type QueryResolvers<ContextType = MeshContext, ParentType extends Resolve
 }>;
 
 export type SubscriptionResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = ResolversObject<{
+  aggregation?: SubscriptionResolver<Maybe<ResolversTypes['Aggregation']>, "aggregation", ParentType, ContextType, RequireFields<SubscriptionaggregationArgs, 'id' | 'subgraphError'>>;
+  aggregations?: SubscriptionResolver<Array<ResolversTypes['Aggregation']>, "aggregations", ParentType, ContextType, RequireFields<SubscriptionaggregationsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  depositor?: SubscriptionResolver<Maybe<ResolversTypes['Depositor']>, "depositor", ParentType, ContextType, RequireFields<SubscriptiondepositorArgs, 'id' | 'subgraphError'>>;
+  depositors?: SubscriptionResolver<Array<ResolversTypes['Depositor']>, "depositors", ParentType, ContextType, RequireFields<SubscriptiondepositorsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  dailyDeposit?: SubscriptionResolver<Maybe<ResolversTypes['DailyDeposit']>, "dailyDeposit", ParentType, ContextType, RequireFields<SubscriptiondailyDepositArgs, 'id' | 'subgraphError'>>;
+  dailyDeposits?: SubscriptionResolver<Array<ResolversTypes['DailyDeposit']>, "dailyDeposits", ParentType, ContextType, RequireFields<SubscriptiondailyDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  deposit?: SubscriptionResolver<Maybe<ResolversTypes['Deposit']>, "deposit", ParentType, ContextType, RequireFields<SubscriptiondepositArgs, 'id' | 'subgraphError'>>;
+  deposits?: SubscriptionResolver<Array<ResolversTypes['Deposit']>, "deposits", ParentType, ContextType, RequireFields<SubscriptiondepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  _meta?: SubscriptionResolver<Maybe<ResolversTypes['_Meta_']>, "_meta", ParentType, ContextType, Partial<Subscription_metaArgs>>;
   delegateChange?: SubscriptionResolver<Maybe<ResolversTypes['DelegateChange']>, "delegateChange", ParentType, ContextType, RequireFields<SubscriptiondelegateChangeArgs, 'id' | 'subgraphError'>>;
   delegateChanges?: SubscriptionResolver<Array<ResolversTypes['DelegateChange']>, "delegateChanges", ParentType, ContextType, RequireFields<SubscriptiondelegateChangesArgs, 'skip' | 'first' | 'subgraphError'>>;
   delegateVotingPowerChange?: SubscriptionResolver<Maybe<ResolversTypes['DelegateVotingPowerChange']>, "delegateVotingPowerChange", ParentType, ContextType, RequireFields<SubscriptiondelegateVotingPowerChangeArgs, 'id' | 'subgraphError'>>;
@@ -8537,15 +8546,6 @@ export type SubscriptionResolvers<ContextType = MeshContext, ParentType extends 
   tokenDailySnapshots?: SubscriptionResolver<Array<ResolversTypes['TokenDailySnapshot']>, "tokenDailySnapshots", ParentType, ContextType, RequireFields<SubscriptiontokenDailySnapshotsArgs, 'skip' | 'first' | 'subgraphError'>>;
   voteDailySnapshot?: SubscriptionResolver<Maybe<ResolversTypes['VoteDailySnapshot']>, "voteDailySnapshot", ParentType, ContextType, RequireFields<SubscriptionvoteDailySnapshotArgs, 'id' | 'subgraphError'>>;
   voteDailySnapshots?: SubscriptionResolver<Array<ResolversTypes['VoteDailySnapshot']>, "voteDailySnapshots", ParentType, ContextType, RequireFields<SubscriptionvoteDailySnapshotsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  _meta?: SubscriptionResolver<Maybe<ResolversTypes['_Meta_']>, "_meta", ParentType, ContextType, Partial<Subscription_metaArgs>>;
-  aggregation?: SubscriptionResolver<Maybe<ResolversTypes['Aggregation']>, "aggregation", ParentType, ContextType, RequireFields<SubscriptionaggregationArgs, 'id' | 'subgraphError'>>;
-  aggregations?: SubscriptionResolver<Array<ResolversTypes['Aggregation']>, "aggregations", ParentType, ContextType, RequireFields<SubscriptionaggregationsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  depositor?: SubscriptionResolver<Maybe<ResolversTypes['Depositor']>, "depositor", ParentType, ContextType, RequireFields<SubscriptiondepositorArgs, 'id' | 'subgraphError'>>;
-  depositors?: SubscriptionResolver<Array<ResolversTypes['Depositor']>, "depositors", ParentType, ContextType, RequireFields<SubscriptiondepositorsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  dailyDeposit?: SubscriptionResolver<Maybe<ResolversTypes['DailyDeposit']>, "dailyDeposit", ParentType, ContextType, RequireFields<SubscriptiondailyDepositArgs, 'id' | 'subgraphError'>>;
-  dailyDeposits?: SubscriptionResolver<Array<ResolversTypes['DailyDeposit']>, "dailyDeposits", ParentType, ContextType, RequireFields<SubscriptiondailyDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  deposit?: SubscriptionResolver<Maybe<ResolversTypes['Deposit']>, "deposit", ParentType, ContextType, RequireFields<SubscriptiondepositArgs, 'id' | 'subgraphError'>>;
-  deposits?: SubscriptionResolver<Array<ResolversTypes['Deposit']>, "deposits", ParentType, ContextType, RequireFields<SubscriptiondepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
   account?: SubscriptionResolver<Maybe<ResolversTypes['Account']>, "account", ParentType, ContextType, RequireFields<SubscriptionaccountArgs, 'id' | 'subgraphError'>>;
   accounts?: SubscriptionResolver<Array<ResolversTypes['Account']>, "accounts", ParentType, ContextType, RequireFields<SubscriptionaccountsArgs, 'skip' | 'first' | 'subgraphError'>>;
   punk?: SubscriptionResolver<Maybe<ResolversTypes['Punk']>, "punk", ParentType, ContextType, RequireFields<SubscriptionpunkArgs, 'id' | 'subgraphError'>>;
@@ -8594,6 +8594,14 @@ export type SubscriptionResolvers<ContextType = MeshContext, ParentType extends 
   offers?: SubscriptionResolver<Array<ResolversTypes['Offer']>, "offers", ParentType, ContextType, RequireFields<SubscriptionoffersArgs, 'skip' | 'first' | 'subgraphError'>>;
 }>;
 
+export type AggregationResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Aggregation'] = ResolversParentTypes['Aggregation']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  totalDeposits?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  totalDepositors?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  totalAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export interface BigDecimalScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['BigDecimal'], any> {
   name: 'BigDecimal';
 }
@@ -8605,6 +8613,46 @@ export interface BigIntScalarConfig extends GraphQLScalarTypeConfig<ResolversTyp
 export interface BytesScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Bytes'], any> {
   name: 'Bytes';
 }
+
+export type DailyDepositResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['DailyDeposit'] = ResolversParentTypes['DailyDeposit']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  dailyAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  dailyDepositCount?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type DepositResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Deposit'] = ResolversParentTypes['Deposit']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  dayID?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  depositor?: Resolver<Maybe<ResolversTypes['Depositor']>, ParentType, ContextType>;
+  pubkey?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  withdrawal_credentials?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  amount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type DepositorResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Depositor'] = ResolversParentTypes['Depositor']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  totalAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  depositCount?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  deposits?: Resolver<Maybe<Array<ResolversTypes['Deposit']>>, ParentType, ContextType, RequireFields<DepositordepositsArgs, 'skip' | 'first'>>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type _Block_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Block_'] = ResolversParentTypes['_Block_']> = ResolversObject<{
+  hash?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
+  number?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  timestamp?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type _Meta_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Meta_'] = ResolversParentTypes['_Meta_']> = ResolversObject<{
+  block?: Resolver<ResolversTypes['_Block_'], ParentType, ContextType>;
+  deployment?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hasIndexingErrors?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
 
 export type DelegateResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Delegate'] = ResolversParentTypes['Delegate']> = ResolversObject<{
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -8759,54 +8807,6 @@ export type VoteDailySnapshotResolvers<ContextType = MeshContext, ParentType ext
   totalWeightedVotes?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
   blockNumber?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
   timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type _Block_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Block_'] = ResolversParentTypes['_Block_']> = ResolversObject<{
-  hash?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
-  number?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  timestamp?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type _Meta_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Meta_'] = ResolversParentTypes['_Meta_']> = ResolversObject<{
-  block?: Resolver<ResolversTypes['_Block_'], ParentType, ContextType>;
-  deployment?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  hasIndexingErrors?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type AggregationResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Aggregation'] = ResolversParentTypes['Aggregation']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  totalDeposits?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  totalDepositors?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  totalAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type DailyDepositResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['DailyDeposit'] = ResolversParentTypes['DailyDeposit']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  dailyAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  dailyDepositCount?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type DepositResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Deposit'] = ResolversParentTypes['Deposit']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  dayID?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  depositor?: Resolver<Maybe<ResolversTypes['Depositor']>, ParentType, ContextType>;
-  pubkey?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
-  withdrawal_credentials?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
-  amount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
-  timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type DepositorResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Depositor'] = ResolversParentTypes['Depositor']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  totalAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  depositCount?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  deposits?: Resolver<Maybe<Array<ResolversTypes['Deposit']>>, ParentType, ContextType, RequireFields<DepositordepositsArgs, 'skip' | 'first'>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -9142,9 +9142,15 @@ export type WrapResolvers<ContextType = MeshContext, ParentType extends Resolver
 export type Resolvers<ContextType = MeshContext> = ResolversObject<{
   Query?: QueryResolvers<ContextType>;
   Subscription?: SubscriptionResolvers<ContextType>;
+  Aggregation?: AggregationResolvers<ContextType>;
   BigDecimal?: GraphQLScalarType;
   BigInt?: GraphQLScalarType;
   Bytes?: GraphQLScalarType;
+  DailyDeposit?: DailyDepositResolvers<ContextType>;
+  Deposit?: DepositResolvers<ContextType>;
+  Depositor?: DepositorResolvers<ContextType>;
+  _Block_?: _Block_Resolvers<ContextType>;
+  _Meta_?: _Meta_Resolvers<ContextType>;
   Delegate?: DelegateResolvers<ContextType>;
   DelegateChange?: DelegateChangeResolvers<ContextType>;
   DelegateVotingPowerChange?: DelegateVotingPowerChangeResolvers<ContextType>;
@@ -9155,12 +9161,6 @@ export type Resolvers<ContextType = MeshContext> = ResolversObject<{
   TokenHolder?: TokenHolderResolvers<ContextType>;
   Vote?: VoteResolvers<ContextType>;
   VoteDailySnapshot?: VoteDailySnapshotResolvers<ContextType>;
-  _Block_?: _Block_Resolvers<ContextType>;
-  _Meta_?: _Meta_Resolvers<ContextType>;
-  Aggregation?: AggregationResolvers<ContextType>;
-  DailyDeposit?: DailyDepositResolvers<ContextType>;
-  Deposit?: DepositResolvers<ContextType>;
-  Depositor?: DepositorResolvers<ContextType>;
   Account?: AccountResolvers<ContextType>;
   Ask?: AskResolvers<ContextType>;
   AskCreated?: AskCreatedResolvers<ContextType>;
@@ -9192,7 +9192,7 @@ export type DirectiveResolvers<ContextType = MeshContext> = ResolversObject<{
   derivedFrom?: derivedFromDirectiveResolver<any, any, ContextType>;
 }>;
 
-export type MeshContext = EnsGovernanceTypes.Context & BeaconDepositorsTypes.Context & CryptopunksTypes.Context & BaseMeshContext;
+export type MeshContext = BeaconDepositorsTypes.Context & EnsGovernanceTypes.Context & CryptopunksTypes.Context & BaseMeshContext;
 
 
 const baseDir = pathModule.join(typeof __dirname === 'string' ? __dirname : '/', '..');
@@ -9200,11 +9200,11 @@ const baseDir = pathModule.join(typeof __dirname === 'string' ? __dirname : '/',
 const importFn: ImportFn = <T>(moduleId: string) => {
   const relativeModuleId = (pathModule.isAbsolute(moduleId) ? pathModule.relative(baseDir, moduleId) : moduleId).split('\\').join('/').replace(baseDir + '/', '');
   switch(relativeModuleId) {
-    case ".graphclient/sources/ens-governance/introspectionSchema":
-      return import("./sources/ens-governance/introspectionSchema") as T;
-    
     case ".graphclient/sources/beacon-depositors/introspectionSchema":
       return import("./sources/beacon-depositors/introspectionSchema") as T;
+    
+    case ".graphclient/sources/ens-governance/introspectionSchema":
+      return import("./sources/ens-governance/introspectionSchema") as T;
     
     case ".graphclient/sources/cryptopunks/introspectionSchema":
       return import("./sources/cryptopunks/introspectionSchema") as T;
@@ -9393,7 +9393,7 @@ export type PunkOwnersQuery = { punks: Array<{ owner: Pick<Account, 'id'> }> };
 
 export const BeaconDepositorsDocument = gql`
     query BeaconDepositors($skip: Int) {
-  depositors(skip: $skip) {
+  depositors(first: 1000, skip: $skip) {
     id
   }
 }
@@ -9402,7 +9402,7 @@ export const VotersPerProposalDocument = gql`
     query VotersPerProposal($id: ID!, $choice: VoteChoice, $skip: Int) {
   proposal(id: $id) {
     state
-    votes(where: {choice: $choice}) {
+    votes(first: 1000, skip: $skip, where: {choice: $choice}) {
       voter {
         id
       }

--- a/apis/query/src/lib/graph/.graphclient/index.ts
+++ b/apis/query/src/lib/graph/.graphclient/index.ts
@@ -20,9 +20,9 @@ import { getMesh, ExecuteMeshFn, SubscribeMeshFn, MeshContext as BaseMeshContext
 import { MeshStore, FsStoreStorageAdapter } from '@graphql-mesh/store';
 import { path as pathModule } from '@graphql-mesh/cross-helpers';
 import { ImportFn } from '@graphql-mesh/types';
-import type { EnsGovernanceTypes } from './sources/ens-governance/types';
 import type { BeaconDepositorsTypes } from './sources/beacon-depositors/types';
 import type { CryptopunksTypes } from './sources/cryptopunks/types';
+import type { EnsGovernanceTypes } from './sources/ens-governance/types';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -45,6 +45,16 @@ export type Scalars = {
 };
 
 export type Query = {
+  aggregation?: Maybe<Aggregation>;
+  aggregations: Array<Aggregation>;
+  depositor?: Maybe<Depositor>;
+  depositors: Array<Depositor>;
+  dailyDeposit?: Maybe<DailyDeposit>;
+  dailyDeposits: Array<DailyDeposit>;
+  deposit?: Maybe<Deposit>;
+  deposits: Array<Deposit>;
+  /** Access to subgraph metadata */
+  _meta?: Maybe<_Meta_>;
   delegateChange?: Maybe<DelegateChange>;
   delegateChanges: Array<DelegateChange>;
   delegateVotingPowerChange?: Maybe<DelegateVotingPowerChange>;
@@ -65,16 +75,6 @@ export type Query = {
   tokenDailySnapshots: Array<TokenDailySnapshot>;
   voteDailySnapshot?: Maybe<VoteDailySnapshot>;
   voteDailySnapshots: Array<VoteDailySnapshot>;
-  /** Access to subgraph metadata */
-  _meta?: Maybe<_Meta_>;
-  aggregation?: Maybe<Aggregation>;
-  aggregations: Array<Aggregation>;
-  depositor?: Maybe<Depositor>;
-  depositors: Array<Depositor>;
-  dailyDeposit?: Maybe<DailyDeposit>;
-  dailyDeposits: Array<DailyDeposit>;
-  deposit?: Maybe<Deposit>;
-  deposits: Array<Deposit>;
   account?: Maybe<Account>;
   accounts: Array<Account>;
   punk?: Maybe<Punk>;
@@ -121,6 +121,83 @@ export type Query = {
   events: Array<Event>;
   offer?: Maybe<Offer>;
   offers: Array<Offer>;
+};
+
+
+export type QueryaggregationArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryaggregationsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Aggregation_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Aggregation_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydepositorArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydepositorsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Depositor_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Depositor_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydailyDepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydailyDepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<DailyDeposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<DailyDeposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Deposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Deposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type Query_metaArgs = {
+  block?: InputMaybe<Block_height>;
 };
 
 
@@ -299,83 +376,6 @@ export type QueryvoteDailySnapshotsArgs = {
   orderBy?: InputMaybe<VoteDailySnapshot_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<VoteDailySnapshot_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type Query_metaArgs = {
-  block?: InputMaybe<Block_height>;
-};
-
-
-export type QueryaggregationArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QueryaggregationsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Aggregation_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Aggregation_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydepositorArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydepositorsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Depositor_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Depositor_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydailyDepositArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydailyDepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<DailyDeposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<DailyDeposit_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydepositArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Deposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Deposit_filter>;
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
@@ -795,6 +795,16 @@ export type QueryoffersArgs = {
 };
 
 export type Subscription = {
+  aggregation?: Maybe<Aggregation>;
+  aggregations: Array<Aggregation>;
+  depositor?: Maybe<Depositor>;
+  depositors: Array<Depositor>;
+  dailyDeposit?: Maybe<DailyDeposit>;
+  dailyDeposits: Array<DailyDeposit>;
+  deposit?: Maybe<Deposit>;
+  deposits: Array<Deposit>;
+  /** Access to subgraph metadata */
+  _meta?: Maybe<_Meta_>;
   delegateChange?: Maybe<DelegateChange>;
   delegateChanges: Array<DelegateChange>;
   delegateVotingPowerChange?: Maybe<DelegateVotingPowerChange>;
@@ -815,16 +825,6 @@ export type Subscription = {
   tokenDailySnapshots: Array<TokenDailySnapshot>;
   voteDailySnapshot?: Maybe<VoteDailySnapshot>;
   voteDailySnapshots: Array<VoteDailySnapshot>;
-  /** Access to subgraph metadata */
-  _meta?: Maybe<_Meta_>;
-  aggregation?: Maybe<Aggregation>;
-  aggregations: Array<Aggregation>;
-  depositor?: Maybe<Depositor>;
-  depositors: Array<Depositor>;
-  dailyDeposit?: Maybe<DailyDeposit>;
-  dailyDeposits: Array<DailyDeposit>;
-  deposit?: Maybe<Deposit>;
-  deposits: Array<Deposit>;
   account?: Maybe<Account>;
   accounts: Array<Account>;
   punk?: Maybe<Punk>;
@@ -871,6 +871,83 @@ export type Subscription = {
   events: Array<Event>;
   offer?: Maybe<Offer>;
   offers: Array<Offer>;
+};
+
+
+export type SubscriptionaggregationArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionaggregationsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Aggregation_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Aggregation_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondepositorArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondepositorsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Depositor_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Depositor_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondailyDepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondailyDepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<DailyDeposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<DailyDeposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Deposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Deposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type Subscription_metaArgs = {
+  block?: InputMaybe<Block_height>;
 };
 
 
@@ -1049,83 +1126,6 @@ export type SubscriptionvoteDailySnapshotsArgs = {
   orderBy?: InputMaybe<VoteDailySnapshot_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<VoteDailySnapshot_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type Subscription_metaArgs = {
-  block?: InputMaybe<Block_height>;
-};
-
-
-export type SubscriptionaggregationArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptionaggregationsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Aggregation_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Aggregation_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondepositorArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondepositorsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Depositor_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Depositor_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondailyDepositArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondailyDepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<DailyDeposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<DailyDeposit_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondepositArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Deposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Deposit_filter>;
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
@@ -1544,6 +1544,58 @@ export type SubscriptionoffersArgs = {
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+export type Aggregation = {
+  id: Scalars['ID'];
+  totalDeposits?: Maybe<Scalars['BigInt']>;
+  totalDepositors?: Maybe<Scalars['BigInt']>;
+  totalAmountDeposited?: Maybe<Scalars['BigInt']>;
+};
+
+export type Aggregation_filter = {
+  id?: InputMaybe<Scalars['ID']>;
+  id_not?: InputMaybe<Scalars['ID']>;
+  id_gt?: InputMaybe<Scalars['ID']>;
+  id_lt?: InputMaybe<Scalars['ID']>;
+  id_gte?: InputMaybe<Scalars['ID']>;
+  id_lte?: InputMaybe<Scalars['ID']>;
+  id_in?: InputMaybe<Array<Scalars['ID']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  totalDeposits?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_not?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_gt?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_lt?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_gte?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_lte?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalDeposits_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalDepositors?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_not?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_gt?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_lt?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_gte?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_lte?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalDepositors_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalAmountDeposited?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
+};
+
+export type Aggregation_orderBy =
+  | 'id'
+  | 'totalDeposits'
+  | 'totalDepositors'
+  | 'totalAmountDeposited';
+
 export type BlockChangedFilter = {
   number_gte: Scalars['Int'];
 };
@@ -1553,6 +1605,252 @@ export type Block_height = {
   number?: InputMaybe<Scalars['Int']>;
   number_gte?: InputMaybe<Scalars['Int']>;
 };
+
+export type DailyDeposit = {
+  id: Scalars['ID'];
+  dailyAmountDeposited?: Maybe<Scalars['BigInt']>;
+  dailyDepositCount?: Maybe<Scalars['BigInt']>;
+};
+
+export type DailyDeposit_filter = {
+  id?: InputMaybe<Scalars['ID']>;
+  id_not?: InputMaybe<Scalars['ID']>;
+  id_gt?: InputMaybe<Scalars['ID']>;
+  id_lt?: InputMaybe<Scalars['ID']>;
+  id_gte?: InputMaybe<Scalars['ID']>;
+  id_lte?: InputMaybe<Scalars['ID']>;
+  id_in?: InputMaybe<Array<Scalars['ID']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  dailyAmountDeposited?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  dailyAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  dailyDepositCount?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_not?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_gt?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_lt?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_gte?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_lte?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  dailyDepositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
+};
+
+export type DailyDeposit_orderBy =
+  | 'id'
+  | 'dailyAmountDeposited'
+  | 'dailyDepositCount';
+
+export type Deposit = {
+  id: Scalars['ID'];
+  dayID: Scalars['String'];
+  depositor?: Maybe<Depositor>;
+  pubkey: Scalars['Bytes'];
+  withdrawal_credentials: Scalars['Bytes'];
+  amount: Scalars['BigInt'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type Deposit_filter = {
+  id?: InputMaybe<Scalars['ID']>;
+  id_not?: InputMaybe<Scalars['ID']>;
+  id_gt?: InputMaybe<Scalars['ID']>;
+  id_lt?: InputMaybe<Scalars['ID']>;
+  id_gte?: InputMaybe<Scalars['ID']>;
+  id_lte?: InputMaybe<Scalars['ID']>;
+  id_in?: InputMaybe<Array<Scalars['ID']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  dayID?: InputMaybe<Scalars['String']>;
+  dayID_not?: InputMaybe<Scalars['String']>;
+  dayID_gt?: InputMaybe<Scalars['String']>;
+  dayID_lt?: InputMaybe<Scalars['String']>;
+  dayID_gte?: InputMaybe<Scalars['String']>;
+  dayID_lte?: InputMaybe<Scalars['String']>;
+  dayID_in?: InputMaybe<Array<Scalars['String']>>;
+  dayID_not_in?: InputMaybe<Array<Scalars['String']>>;
+  dayID_contains?: InputMaybe<Scalars['String']>;
+  dayID_contains_nocase?: InputMaybe<Scalars['String']>;
+  dayID_not_contains?: InputMaybe<Scalars['String']>;
+  dayID_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  dayID_starts_with?: InputMaybe<Scalars['String']>;
+  dayID_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  dayID_not_starts_with?: InputMaybe<Scalars['String']>;
+  dayID_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  dayID_ends_with?: InputMaybe<Scalars['String']>;
+  dayID_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  dayID_not_ends_with?: InputMaybe<Scalars['String']>;
+  dayID_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor?: InputMaybe<Scalars['String']>;
+  depositor_not?: InputMaybe<Scalars['String']>;
+  depositor_gt?: InputMaybe<Scalars['String']>;
+  depositor_lt?: InputMaybe<Scalars['String']>;
+  depositor_gte?: InputMaybe<Scalars['String']>;
+  depositor_lte?: InputMaybe<Scalars['String']>;
+  depositor_in?: InputMaybe<Array<Scalars['String']>>;
+  depositor_not_in?: InputMaybe<Array<Scalars['String']>>;
+  depositor_contains?: InputMaybe<Scalars['String']>;
+  depositor_contains_nocase?: InputMaybe<Scalars['String']>;
+  depositor_not_contains?: InputMaybe<Scalars['String']>;
+  depositor_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  depositor_starts_with?: InputMaybe<Scalars['String']>;
+  depositor_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor_not_starts_with?: InputMaybe<Scalars['String']>;
+  depositor_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor_ends_with?: InputMaybe<Scalars['String']>;
+  depositor_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor_not_ends_with?: InputMaybe<Scalars['String']>;
+  depositor_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor_?: InputMaybe<Depositor_filter>;
+  pubkey?: InputMaybe<Scalars['Bytes']>;
+  pubkey_not?: InputMaybe<Scalars['Bytes']>;
+  pubkey_gt?: InputMaybe<Scalars['Bytes']>;
+  pubkey_lt?: InputMaybe<Scalars['Bytes']>;
+  pubkey_gte?: InputMaybe<Scalars['Bytes']>;
+  pubkey_lte?: InputMaybe<Scalars['Bytes']>;
+  pubkey_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  pubkey_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  pubkey_contains?: InputMaybe<Scalars['Bytes']>;
+  pubkey_not_contains?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_not?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_gt?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_lt?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_gte?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_lte?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  withdrawal_credentials_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  withdrawal_credentials_contains?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_not_contains?: InputMaybe<Scalars['Bytes']>;
+  amount?: InputMaybe<Scalars['BigInt']>;
+  amount_not?: InputMaybe<Scalars['BigInt']>;
+  amount_gt?: InputMaybe<Scalars['BigInt']>;
+  amount_lt?: InputMaybe<Scalars['BigInt']>;
+  amount_gte?: InputMaybe<Scalars['BigInt']>;
+  amount_lte?: InputMaybe<Scalars['BigInt']>;
+  amount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  amount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
+};
+
+export type Deposit_orderBy =
+  | 'id'
+  | 'dayID'
+  | 'depositor'
+  | 'depositor__id'
+  | 'depositor__totalAmountDeposited'
+  | 'depositor__depositCount'
+  | 'pubkey'
+  | 'withdrawal_credentials'
+  | 'amount'
+  | 'timestamp';
+
+export type Depositor = {
+  id: Scalars['ID'];
+  totalAmountDeposited?: Maybe<Scalars['BigInt']>;
+  depositCount?: Maybe<Scalars['BigInt']>;
+  deposits?: Maybe<Array<Deposit>>;
+};
+
+
+export type DepositordepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Deposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Deposit_filter>;
+};
+
+export type Depositor_filter = {
+  id?: InputMaybe<Scalars['ID']>;
+  id_not?: InputMaybe<Scalars['ID']>;
+  id_gt?: InputMaybe<Scalars['ID']>;
+  id_lt?: InputMaybe<Scalars['ID']>;
+  id_gte?: InputMaybe<Scalars['ID']>;
+  id_lte?: InputMaybe<Scalars['ID']>;
+  id_in?: InputMaybe<Array<Scalars['ID']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  totalAmountDeposited?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  depositCount?: InputMaybe<Scalars['BigInt']>;
+  depositCount_not?: InputMaybe<Scalars['BigInt']>;
+  depositCount_gt?: InputMaybe<Scalars['BigInt']>;
+  depositCount_lt?: InputMaybe<Scalars['BigInt']>;
+  depositCount_gte?: InputMaybe<Scalars['BigInt']>;
+  depositCount_lte?: InputMaybe<Scalars['BigInt']>;
+  depositCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  depositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposits_?: InputMaybe<Deposit_filter>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
+};
+
+export type Depositor_orderBy =
+  | 'id'
+  | 'totalAmountDeposited'
+  | 'depositCount'
+  | 'deposits';
+
+/** Defines the order direction, either ascending or descending */
+export type OrderDirection =
+  | 'asc'
+  | 'desc';
+
+export type _Block_ = {
+  /** The hash of the block */
+  hash?: Maybe<Scalars['Bytes']>;
+  /** The block number */
+  number: Scalars['Int'];
+  /** Integer representation of the timestamp stored in blocks for the chain */
+  timestamp?: Maybe<Scalars['Int']>;
+};
+
+/** The type for the top-level _meta field */
+export type _Meta_ = {
+  /**
+   * Information about a specific subgraph block. The hash of the block
+   * will be null if the _meta field has a block constraint that asks for
+   * a block number. It will be filled if the _meta field has no block constraint
+   * and therefore asks for the latest  block
+   *
+   */
+  block: _Block_;
+  /** The deployment ID */
+  deployment: Scalars['String'];
+  /** If `true`, the subgraph encountered indexing errors at some past block */
+  hasIndexingErrors: Scalars['Boolean'];
+};
+
+export type _SubgraphErrorPolicy_ =
+  /** Data will be returned even if the subgraph has indexing errors */
+  | 'allow'
+  /** If the subgraph has indexing errors, data will be omitted. The default. */
+  | 'deny';
 
 export type Delegate = {
   /** A Delegate is any address that has been delegated with voting tokens by a token holder, id is the blockchain address of said delegate */
@@ -2351,11 +2649,6 @@ export type Governance_orderBy =
   | 'proposalsQueued'
   | 'proposalsExecuted'
   | 'proposalsCanceled';
-
-/** Defines the order direction, either ascending or descending */
-export type OrderDirection =
-  | 'asc'
-  | 'desc';
 
 export type Proposal = {
   /** Internal proposal ID, in this implementation it seems to be a autoincremental id */
@@ -3296,299 +3589,6 @@ export type Vote_orderBy =
   | 'block'
   | 'blockTime'
   | 'txnHash';
-
-export type _Block_ = {
-  /** The hash of the block */
-  hash?: Maybe<Scalars['Bytes']>;
-  /** The block number */
-  number: Scalars['Int'];
-  /** Integer representation of the timestamp stored in blocks for the chain */
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** The type for the top-level _meta field */
-export type _Meta_ = {
-  /**
-   * Information about a specific subgraph block. The hash of the block
-   * will be null if the _meta field has a block constraint that asks for
-   * a block number. It will be filled if the _meta field has no block constraint
-   * and therefore asks for the latest  block
-   *
-   */
-  block: _Block_;
-  /** The deployment ID */
-  deployment: Scalars['String'];
-  /** If `true`, the subgraph encountered indexing errors at some past block */
-  hasIndexingErrors: Scalars['Boolean'];
-};
-
-export type _SubgraphErrorPolicy_ =
-  /** Data will be returned even if the subgraph has indexing errors */
-  | 'allow'
-  /** If the subgraph has indexing errors, data will be omitted. The default. */
-  | 'deny';
-
-export type Aggregation = {
-  id: Scalars['ID'];
-  totalDeposits?: Maybe<Scalars['BigInt']>;
-  totalDepositors?: Maybe<Scalars['BigInt']>;
-  totalAmountDeposited?: Maybe<Scalars['BigInt']>;
-};
-
-export type Aggregation_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  totalDeposits?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_not?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_gt?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_lt?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_gte?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_lte?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalDeposits_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalDepositors?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_not?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_gt?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_lt?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_gte?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_lte?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalDepositors_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalAmountDeposited?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
-};
-
-export type Aggregation_orderBy =
-  | 'id'
-  | 'totalDeposits'
-  | 'totalDepositors'
-  | 'totalAmountDeposited';
-
-export type DailyDeposit = {
-  id: Scalars['ID'];
-  dailyAmountDeposited?: Maybe<Scalars['BigInt']>;
-  dailyDepositCount?: Maybe<Scalars['BigInt']>;
-};
-
-export type DailyDeposit_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  dailyAmountDeposited?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  dailyAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  dailyDepositCount?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_not?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_gt?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_lt?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_gte?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_lte?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  dailyDepositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
-};
-
-export type DailyDeposit_orderBy =
-  | 'id'
-  | 'dailyAmountDeposited'
-  | 'dailyDepositCount';
-
-export type Deposit = {
-  id: Scalars['ID'];
-  dayID: Scalars['String'];
-  depositor?: Maybe<Depositor>;
-  pubkey: Scalars['Bytes'];
-  withdrawal_credentials: Scalars['Bytes'];
-  amount: Scalars['BigInt'];
-  timestamp: Scalars['BigInt'];
-};
-
-export type Deposit_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  dayID?: InputMaybe<Scalars['String']>;
-  dayID_not?: InputMaybe<Scalars['String']>;
-  dayID_gt?: InputMaybe<Scalars['String']>;
-  dayID_lt?: InputMaybe<Scalars['String']>;
-  dayID_gte?: InputMaybe<Scalars['String']>;
-  dayID_lte?: InputMaybe<Scalars['String']>;
-  dayID_in?: InputMaybe<Array<Scalars['String']>>;
-  dayID_not_in?: InputMaybe<Array<Scalars['String']>>;
-  dayID_contains?: InputMaybe<Scalars['String']>;
-  dayID_contains_nocase?: InputMaybe<Scalars['String']>;
-  dayID_not_contains?: InputMaybe<Scalars['String']>;
-  dayID_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  dayID_starts_with?: InputMaybe<Scalars['String']>;
-  dayID_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  dayID_not_starts_with?: InputMaybe<Scalars['String']>;
-  dayID_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  dayID_ends_with?: InputMaybe<Scalars['String']>;
-  dayID_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  dayID_not_ends_with?: InputMaybe<Scalars['String']>;
-  dayID_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor?: InputMaybe<Scalars['String']>;
-  depositor_not?: InputMaybe<Scalars['String']>;
-  depositor_gt?: InputMaybe<Scalars['String']>;
-  depositor_lt?: InputMaybe<Scalars['String']>;
-  depositor_gte?: InputMaybe<Scalars['String']>;
-  depositor_lte?: InputMaybe<Scalars['String']>;
-  depositor_in?: InputMaybe<Array<Scalars['String']>>;
-  depositor_not_in?: InputMaybe<Array<Scalars['String']>>;
-  depositor_contains?: InputMaybe<Scalars['String']>;
-  depositor_contains_nocase?: InputMaybe<Scalars['String']>;
-  depositor_not_contains?: InputMaybe<Scalars['String']>;
-  depositor_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  depositor_starts_with?: InputMaybe<Scalars['String']>;
-  depositor_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor_not_starts_with?: InputMaybe<Scalars['String']>;
-  depositor_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor_ends_with?: InputMaybe<Scalars['String']>;
-  depositor_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor_not_ends_with?: InputMaybe<Scalars['String']>;
-  depositor_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor_?: InputMaybe<Depositor_filter>;
-  pubkey?: InputMaybe<Scalars['Bytes']>;
-  pubkey_not?: InputMaybe<Scalars['Bytes']>;
-  pubkey_gt?: InputMaybe<Scalars['Bytes']>;
-  pubkey_lt?: InputMaybe<Scalars['Bytes']>;
-  pubkey_gte?: InputMaybe<Scalars['Bytes']>;
-  pubkey_lte?: InputMaybe<Scalars['Bytes']>;
-  pubkey_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  pubkey_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  pubkey_contains?: InputMaybe<Scalars['Bytes']>;
-  pubkey_not_contains?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_not?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_gt?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_lt?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_gte?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_lte?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  withdrawal_credentials_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  withdrawal_credentials_contains?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_not_contains?: InputMaybe<Scalars['Bytes']>;
-  amount?: InputMaybe<Scalars['BigInt']>;
-  amount_not?: InputMaybe<Scalars['BigInt']>;
-  amount_gt?: InputMaybe<Scalars['BigInt']>;
-  amount_lt?: InputMaybe<Scalars['BigInt']>;
-  amount_gte?: InputMaybe<Scalars['BigInt']>;
-  amount_lte?: InputMaybe<Scalars['BigInt']>;
-  amount_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  amount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  timestamp?: InputMaybe<Scalars['BigInt']>;
-  timestamp_not?: InputMaybe<Scalars['BigInt']>;
-  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
-  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
-  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
-  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
-  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
-};
-
-export type Deposit_orderBy =
-  | 'id'
-  | 'dayID'
-  | 'depositor'
-  | 'depositor__id'
-  | 'depositor__totalAmountDeposited'
-  | 'depositor__depositCount'
-  | 'pubkey'
-  | 'withdrawal_credentials'
-  | 'amount'
-  | 'timestamp';
-
-export type Depositor = {
-  id: Scalars['ID'];
-  totalAmountDeposited?: Maybe<Scalars['BigInt']>;
-  depositCount?: Maybe<Scalars['BigInt']>;
-  deposits?: Maybe<Array<Deposit>>;
-};
-
-
-export type DepositordepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Deposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Deposit_filter>;
-};
-
-export type Depositor_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  totalAmountDeposited?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  depositCount?: InputMaybe<Scalars['BigInt']>;
-  depositCount_not?: InputMaybe<Scalars['BigInt']>;
-  depositCount_gt?: InputMaybe<Scalars['BigInt']>;
-  depositCount_lt?: InputMaybe<Scalars['BigInt']>;
-  depositCount_gte?: InputMaybe<Scalars['BigInt']>;
-  depositCount_lte?: InputMaybe<Scalars['BigInt']>;
-  depositCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  depositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  deposits_?: InputMaybe<Deposit_filter>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
-};
-
-export type Depositor_orderBy =
-  | 'id'
-  | 'totalAmountDeposited'
-  | 'depositCount'
-  | 'deposits';
 
 export type Account = {
   /** Ethereum Address */
@@ -8197,12 +8197,32 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversTypes = ResolversObject<{
   Query: ResolverTypeWrapper<{}>;
   Subscription: ResolverTypeWrapper<{}>;
+  Aggregation: ResolverTypeWrapper<Aggregation>;
+  Aggregation_filter: Aggregation_filter;
+  Aggregation_orderBy: Aggregation_orderBy;
   BigDecimal: ResolverTypeWrapper<Scalars['BigDecimal']>;
   BigInt: ResolverTypeWrapper<Scalars['BigInt']>;
   BlockChangedFilter: BlockChangedFilter;
   Block_height: Block_height;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   Bytes: ResolverTypeWrapper<Scalars['Bytes']>;
+  DailyDeposit: ResolverTypeWrapper<DailyDeposit>;
+  DailyDeposit_filter: DailyDeposit_filter;
+  DailyDeposit_orderBy: DailyDeposit_orderBy;
+  Deposit: ResolverTypeWrapper<Deposit>;
+  Deposit_filter: Deposit_filter;
+  Deposit_orderBy: Deposit_orderBy;
+  Depositor: ResolverTypeWrapper<Depositor>;
+  Depositor_filter: Depositor_filter;
+  Depositor_orderBy: Depositor_orderBy;
+  Float: ResolverTypeWrapper<Scalars['Float']>;
+  ID: ResolverTypeWrapper<Scalars['ID']>;
+  Int: ResolverTypeWrapper<Scalars['Int']>;
+  OrderDirection: OrderDirection;
+  String: ResolverTypeWrapper<Scalars['String']>;
+  _Block_: ResolverTypeWrapper<_Block_>;
+  _Meta_: ResolverTypeWrapper<_Meta_>;
+  _SubgraphErrorPolicy_: _SubgraphErrorPolicy_;
   Delegate: ResolverTypeWrapper<Delegate>;
   DelegateChange: ResolverTypeWrapper<DelegateChange>;
   DelegateChange_filter: DelegateChange_filter;
@@ -8212,7 +8232,6 @@ export type ResolversTypes = ResolversObject<{
   DelegateVotingPowerChange_orderBy: DelegateVotingPowerChange_orderBy;
   Delegate_filter: Delegate_filter;
   Delegate_orderBy: Delegate_orderBy;
-  Float: ResolverTypeWrapper<Scalars['Float']>;
   Governance: ResolverTypeWrapper<Governance>;
   GovernanceFramework: ResolverTypeWrapper<GovernanceFramework>;
   GovernanceFrameworkType: GovernanceFrameworkType;
@@ -8220,14 +8239,10 @@ export type ResolversTypes = ResolversObject<{
   GovernanceFramework_orderBy: GovernanceFramework_orderBy;
   Governance_filter: Governance_filter;
   Governance_orderBy: Governance_orderBy;
-  ID: ResolverTypeWrapper<Scalars['ID']>;
-  Int: ResolverTypeWrapper<Scalars['Int']>;
-  OrderDirection: OrderDirection;
   Proposal: ResolverTypeWrapper<Proposal>;
   ProposalState: ProposalState;
   Proposal_filter: Proposal_filter;
   Proposal_orderBy: Proposal_orderBy;
-  String: ResolverTypeWrapper<Scalars['String']>;
   TokenDailySnapshot: ResolverTypeWrapper<TokenDailySnapshot>;
   TokenDailySnapshot_filter: TokenDailySnapshot_filter;
   TokenDailySnapshot_orderBy: TokenDailySnapshot_orderBy;
@@ -8241,21 +8256,6 @@ export type ResolversTypes = ResolversObject<{
   VoteDailySnapshot_orderBy: VoteDailySnapshot_orderBy;
   Vote_filter: Vote_filter;
   Vote_orderBy: Vote_orderBy;
-  _Block_: ResolverTypeWrapper<_Block_>;
-  _Meta_: ResolverTypeWrapper<_Meta_>;
-  _SubgraphErrorPolicy_: _SubgraphErrorPolicy_;
-  Aggregation: ResolverTypeWrapper<Aggregation>;
-  Aggregation_filter: Aggregation_filter;
-  Aggregation_orderBy: Aggregation_orderBy;
-  DailyDeposit: ResolverTypeWrapper<DailyDeposit>;
-  DailyDeposit_filter: DailyDeposit_filter;
-  DailyDeposit_orderBy: DailyDeposit_orderBy;
-  Deposit: ResolverTypeWrapper<Deposit>;
-  Deposit_filter: Deposit_filter;
-  Deposit_orderBy: Deposit_orderBy;
-  Depositor: ResolverTypeWrapper<Depositor>;
-  Depositor_filter: Depositor_filter;
-  Depositor_orderBy: Depositor_orderBy;
   Account: ResolverTypeWrapper<Account>;
   Account_filter: Account_filter;
   Account_orderBy: Account_orderBy;
@@ -8334,28 +8334,38 @@ export type ResolversTypes = ResolversObject<{
 export type ResolversParentTypes = ResolversObject<{
   Query: {};
   Subscription: {};
+  Aggregation: Aggregation;
+  Aggregation_filter: Aggregation_filter;
   BigDecimal: Scalars['BigDecimal'];
   BigInt: Scalars['BigInt'];
   BlockChangedFilter: BlockChangedFilter;
   Block_height: Block_height;
   Boolean: Scalars['Boolean'];
   Bytes: Scalars['Bytes'];
+  DailyDeposit: DailyDeposit;
+  DailyDeposit_filter: DailyDeposit_filter;
+  Deposit: Deposit;
+  Deposit_filter: Deposit_filter;
+  Depositor: Depositor;
+  Depositor_filter: Depositor_filter;
+  Float: Scalars['Float'];
+  ID: Scalars['ID'];
+  Int: Scalars['Int'];
+  String: Scalars['String'];
+  _Block_: _Block_;
+  _Meta_: _Meta_;
   Delegate: Delegate;
   DelegateChange: DelegateChange;
   DelegateChange_filter: DelegateChange_filter;
   DelegateVotingPowerChange: DelegateVotingPowerChange;
   DelegateVotingPowerChange_filter: DelegateVotingPowerChange_filter;
   Delegate_filter: Delegate_filter;
-  Float: Scalars['Float'];
   Governance: Governance;
   GovernanceFramework: GovernanceFramework;
   GovernanceFramework_filter: GovernanceFramework_filter;
   Governance_filter: Governance_filter;
-  ID: Scalars['ID'];
-  Int: Scalars['Int'];
   Proposal: Proposal;
   Proposal_filter: Proposal_filter;
-  String: Scalars['String'];
   TokenDailySnapshot: TokenDailySnapshot;
   TokenDailySnapshot_filter: TokenDailySnapshot_filter;
   TokenHolder: TokenHolder;
@@ -8364,16 +8374,6 @@ export type ResolversParentTypes = ResolversObject<{
   VoteDailySnapshot: VoteDailySnapshot;
   VoteDailySnapshot_filter: VoteDailySnapshot_filter;
   Vote_filter: Vote_filter;
-  _Block_: _Block_;
-  _Meta_: _Meta_;
-  Aggregation: Aggregation;
-  Aggregation_filter: Aggregation_filter;
-  DailyDeposit: DailyDeposit;
-  DailyDeposit_filter: DailyDeposit_filter;
-  Deposit: Deposit;
-  Deposit_filter: Deposit_filter;
-  Depositor: Depositor;
-  Depositor_filter: Depositor_filter;
   Account: Account;
   Account_filter: Account_filter;
   Ask: Ask;
@@ -8439,6 +8439,15 @@ export type derivedFromDirectiveArgs = {
 export type derivedFromDirectiveResolver<Result, Parent, ContextType = MeshContext, Args = derivedFromDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type QueryResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
+  aggregation?: Resolver<Maybe<ResolversTypes['Aggregation']>, ParentType, ContextType, RequireFields<QueryaggregationArgs, 'id' | 'subgraphError'>>;
+  aggregations?: Resolver<Array<ResolversTypes['Aggregation']>, ParentType, ContextType, RequireFields<QueryaggregationsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  depositor?: Resolver<Maybe<ResolversTypes['Depositor']>, ParentType, ContextType, RequireFields<QuerydepositorArgs, 'id' | 'subgraphError'>>;
+  depositors?: Resolver<Array<ResolversTypes['Depositor']>, ParentType, ContextType, RequireFields<QuerydepositorsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  dailyDeposit?: Resolver<Maybe<ResolversTypes['DailyDeposit']>, ParentType, ContextType, RequireFields<QuerydailyDepositArgs, 'id' | 'subgraphError'>>;
+  dailyDeposits?: Resolver<Array<ResolversTypes['DailyDeposit']>, ParentType, ContextType, RequireFields<QuerydailyDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  deposit?: Resolver<Maybe<ResolversTypes['Deposit']>, ParentType, ContextType, RequireFields<QuerydepositArgs, 'id' | 'subgraphError'>>;
+  deposits?: Resolver<Array<ResolversTypes['Deposit']>, ParentType, ContextType, RequireFields<QuerydepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  _meta?: Resolver<Maybe<ResolversTypes['_Meta_']>, ParentType, ContextType, Partial<Query_metaArgs>>;
   delegateChange?: Resolver<Maybe<ResolversTypes['DelegateChange']>, ParentType, ContextType, RequireFields<QuerydelegateChangeArgs, 'id' | 'subgraphError'>>;
   delegateChanges?: Resolver<Array<ResolversTypes['DelegateChange']>, ParentType, ContextType, RequireFields<QuerydelegateChangesArgs, 'skip' | 'first' | 'subgraphError'>>;
   delegateVotingPowerChange?: Resolver<Maybe<ResolversTypes['DelegateVotingPowerChange']>, ParentType, ContextType, RequireFields<QuerydelegateVotingPowerChangeArgs, 'id' | 'subgraphError'>>;
@@ -8459,15 +8468,6 @@ export type QueryResolvers<ContextType = MeshContext, ParentType extends Resolve
   tokenDailySnapshots?: Resolver<Array<ResolversTypes['TokenDailySnapshot']>, ParentType, ContextType, RequireFields<QuerytokenDailySnapshotsArgs, 'skip' | 'first' | 'subgraphError'>>;
   voteDailySnapshot?: Resolver<Maybe<ResolversTypes['VoteDailySnapshot']>, ParentType, ContextType, RequireFields<QueryvoteDailySnapshotArgs, 'id' | 'subgraphError'>>;
   voteDailySnapshots?: Resolver<Array<ResolversTypes['VoteDailySnapshot']>, ParentType, ContextType, RequireFields<QueryvoteDailySnapshotsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  _meta?: Resolver<Maybe<ResolversTypes['_Meta_']>, ParentType, ContextType, Partial<Query_metaArgs>>;
-  aggregation?: Resolver<Maybe<ResolversTypes['Aggregation']>, ParentType, ContextType, RequireFields<QueryaggregationArgs, 'id' | 'subgraphError'>>;
-  aggregations?: Resolver<Array<ResolversTypes['Aggregation']>, ParentType, ContextType, RequireFields<QueryaggregationsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  depositor?: Resolver<Maybe<ResolversTypes['Depositor']>, ParentType, ContextType, RequireFields<QuerydepositorArgs, 'id' | 'subgraphError'>>;
-  depositors?: Resolver<Array<ResolversTypes['Depositor']>, ParentType, ContextType, RequireFields<QuerydepositorsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  dailyDeposit?: Resolver<Maybe<ResolversTypes['DailyDeposit']>, ParentType, ContextType, RequireFields<QuerydailyDepositArgs, 'id' | 'subgraphError'>>;
-  dailyDeposits?: Resolver<Array<ResolversTypes['DailyDeposit']>, ParentType, ContextType, RequireFields<QuerydailyDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  deposit?: Resolver<Maybe<ResolversTypes['Deposit']>, ParentType, ContextType, RequireFields<QuerydepositArgs, 'id' | 'subgraphError'>>;
-  deposits?: Resolver<Array<ResolversTypes['Deposit']>, ParentType, ContextType, RequireFields<QuerydepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
   account?: Resolver<Maybe<ResolversTypes['Account']>, ParentType, ContextType, RequireFields<QueryaccountArgs, 'id' | 'subgraphError'>>;
   accounts?: Resolver<Array<ResolversTypes['Account']>, ParentType, ContextType, RequireFields<QueryaccountsArgs, 'skip' | 'first' | 'subgraphError'>>;
   punk?: Resolver<Maybe<ResolversTypes['Punk']>, ParentType, ContextType, RequireFields<QuerypunkArgs, 'id' | 'subgraphError'>>;
@@ -8517,6 +8517,15 @@ export type QueryResolvers<ContextType = MeshContext, ParentType extends Resolve
 }>;
 
 export type SubscriptionResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = ResolversObject<{
+  aggregation?: SubscriptionResolver<Maybe<ResolversTypes['Aggregation']>, "aggregation", ParentType, ContextType, RequireFields<SubscriptionaggregationArgs, 'id' | 'subgraphError'>>;
+  aggregations?: SubscriptionResolver<Array<ResolversTypes['Aggregation']>, "aggregations", ParentType, ContextType, RequireFields<SubscriptionaggregationsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  depositor?: SubscriptionResolver<Maybe<ResolversTypes['Depositor']>, "depositor", ParentType, ContextType, RequireFields<SubscriptiondepositorArgs, 'id' | 'subgraphError'>>;
+  depositors?: SubscriptionResolver<Array<ResolversTypes['Depositor']>, "depositors", ParentType, ContextType, RequireFields<SubscriptiondepositorsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  dailyDeposit?: SubscriptionResolver<Maybe<ResolversTypes['DailyDeposit']>, "dailyDeposit", ParentType, ContextType, RequireFields<SubscriptiondailyDepositArgs, 'id' | 'subgraphError'>>;
+  dailyDeposits?: SubscriptionResolver<Array<ResolversTypes['DailyDeposit']>, "dailyDeposits", ParentType, ContextType, RequireFields<SubscriptiondailyDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  deposit?: SubscriptionResolver<Maybe<ResolversTypes['Deposit']>, "deposit", ParentType, ContextType, RequireFields<SubscriptiondepositArgs, 'id' | 'subgraphError'>>;
+  deposits?: SubscriptionResolver<Array<ResolversTypes['Deposit']>, "deposits", ParentType, ContextType, RequireFields<SubscriptiondepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  _meta?: SubscriptionResolver<Maybe<ResolversTypes['_Meta_']>, "_meta", ParentType, ContextType, Partial<Subscription_metaArgs>>;
   delegateChange?: SubscriptionResolver<Maybe<ResolversTypes['DelegateChange']>, "delegateChange", ParentType, ContextType, RequireFields<SubscriptiondelegateChangeArgs, 'id' | 'subgraphError'>>;
   delegateChanges?: SubscriptionResolver<Array<ResolversTypes['DelegateChange']>, "delegateChanges", ParentType, ContextType, RequireFields<SubscriptiondelegateChangesArgs, 'skip' | 'first' | 'subgraphError'>>;
   delegateVotingPowerChange?: SubscriptionResolver<Maybe<ResolversTypes['DelegateVotingPowerChange']>, "delegateVotingPowerChange", ParentType, ContextType, RequireFields<SubscriptiondelegateVotingPowerChangeArgs, 'id' | 'subgraphError'>>;
@@ -8537,15 +8546,6 @@ export type SubscriptionResolvers<ContextType = MeshContext, ParentType extends 
   tokenDailySnapshots?: SubscriptionResolver<Array<ResolversTypes['TokenDailySnapshot']>, "tokenDailySnapshots", ParentType, ContextType, RequireFields<SubscriptiontokenDailySnapshotsArgs, 'skip' | 'first' | 'subgraphError'>>;
   voteDailySnapshot?: SubscriptionResolver<Maybe<ResolversTypes['VoteDailySnapshot']>, "voteDailySnapshot", ParentType, ContextType, RequireFields<SubscriptionvoteDailySnapshotArgs, 'id' | 'subgraphError'>>;
   voteDailySnapshots?: SubscriptionResolver<Array<ResolversTypes['VoteDailySnapshot']>, "voteDailySnapshots", ParentType, ContextType, RequireFields<SubscriptionvoteDailySnapshotsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  _meta?: SubscriptionResolver<Maybe<ResolversTypes['_Meta_']>, "_meta", ParentType, ContextType, Partial<Subscription_metaArgs>>;
-  aggregation?: SubscriptionResolver<Maybe<ResolversTypes['Aggregation']>, "aggregation", ParentType, ContextType, RequireFields<SubscriptionaggregationArgs, 'id' | 'subgraphError'>>;
-  aggregations?: SubscriptionResolver<Array<ResolversTypes['Aggregation']>, "aggregations", ParentType, ContextType, RequireFields<SubscriptionaggregationsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  depositor?: SubscriptionResolver<Maybe<ResolversTypes['Depositor']>, "depositor", ParentType, ContextType, RequireFields<SubscriptiondepositorArgs, 'id' | 'subgraphError'>>;
-  depositors?: SubscriptionResolver<Array<ResolversTypes['Depositor']>, "depositors", ParentType, ContextType, RequireFields<SubscriptiondepositorsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  dailyDeposit?: SubscriptionResolver<Maybe<ResolversTypes['DailyDeposit']>, "dailyDeposit", ParentType, ContextType, RequireFields<SubscriptiondailyDepositArgs, 'id' | 'subgraphError'>>;
-  dailyDeposits?: SubscriptionResolver<Array<ResolversTypes['DailyDeposit']>, "dailyDeposits", ParentType, ContextType, RequireFields<SubscriptiondailyDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  deposit?: SubscriptionResolver<Maybe<ResolversTypes['Deposit']>, "deposit", ParentType, ContextType, RequireFields<SubscriptiondepositArgs, 'id' | 'subgraphError'>>;
-  deposits?: SubscriptionResolver<Array<ResolversTypes['Deposit']>, "deposits", ParentType, ContextType, RequireFields<SubscriptiondepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
   account?: SubscriptionResolver<Maybe<ResolversTypes['Account']>, "account", ParentType, ContextType, RequireFields<SubscriptionaccountArgs, 'id' | 'subgraphError'>>;
   accounts?: SubscriptionResolver<Array<ResolversTypes['Account']>, "accounts", ParentType, ContextType, RequireFields<SubscriptionaccountsArgs, 'skip' | 'first' | 'subgraphError'>>;
   punk?: SubscriptionResolver<Maybe<ResolversTypes['Punk']>, "punk", ParentType, ContextType, RequireFields<SubscriptionpunkArgs, 'id' | 'subgraphError'>>;
@@ -8594,6 +8594,14 @@ export type SubscriptionResolvers<ContextType = MeshContext, ParentType extends 
   offers?: SubscriptionResolver<Array<ResolversTypes['Offer']>, "offers", ParentType, ContextType, RequireFields<SubscriptionoffersArgs, 'skip' | 'first' | 'subgraphError'>>;
 }>;
 
+export type AggregationResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Aggregation'] = ResolversParentTypes['Aggregation']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  totalDeposits?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  totalDepositors?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  totalAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export interface BigDecimalScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['BigDecimal'], any> {
   name: 'BigDecimal';
 }
@@ -8605,6 +8613,46 @@ export interface BigIntScalarConfig extends GraphQLScalarTypeConfig<ResolversTyp
 export interface BytesScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Bytes'], any> {
   name: 'Bytes';
 }
+
+export type DailyDepositResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['DailyDeposit'] = ResolversParentTypes['DailyDeposit']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  dailyAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  dailyDepositCount?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type DepositResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Deposit'] = ResolversParentTypes['Deposit']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  dayID?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  depositor?: Resolver<Maybe<ResolversTypes['Depositor']>, ParentType, ContextType>;
+  pubkey?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  withdrawal_credentials?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  amount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type DepositorResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Depositor'] = ResolversParentTypes['Depositor']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  totalAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  depositCount?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  deposits?: Resolver<Maybe<Array<ResolversTypes['Deposit']>>, ParentType, ContextType, RequireFields<DepositordepositsArgs, 'skip' | 'first'>>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type _Block_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Block_'] = ResolversParentTypes['_Block_']> = ResolversObject<{
+  hash?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
+  number?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  timestamp?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type _Meta_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Meta_'] = ResolversParentTypes['_Meta_']> = ResolversObject<{
+  block?: Resolver<ResolversTypes['_Block_'], ParentType, ContextType>;
+  deployment?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hasIndexingErrors?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
 
 export type DelegateResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Delegate'] = ResolversParentTypes['Delegate']> = ResolversObject<{
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -8759,54 +8807,6 @@ export type VoteDailySnapshotResolvers<ContextType = MeshContext, ParentType ext
   totalWeightedVotes?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
   blockNumber?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
   timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type _Block_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Block_'] = ResolversParentTypes['_Block_']> = ResolversObject<{
-  hash?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
-  number?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  timestamp?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type _Meta_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Meta_'] = ResolversParentTypes['_Meta_']> = ResolversObject<{
-  block?: Resolver<ResolversTypes['_Block_'], ParentType, ContextType>;
-  deployment?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  hasIndexingErrors?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type AggregationResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Aggregation'] = ResolversParentTypes['Aggregation']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  totalDeposits?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  totalDepositors?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  totalAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type DailyDepositResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['DailyDeposit'] = ResolversParentTypes['DailyDeposit']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  dailyAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  dailyDepositCount?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type DepositResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Deposit'] = ResolversParentTypes['Deposit']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  dayID?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  depositor?: Resolver<Maybe<ResolversTypes['Depositor']>, ParentType, ContextType>;
-  pubkey?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
-  withdrawal_credentials?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
-  amount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
-  timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type DepositorResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Depositor'] = ResolversParentTypes['Depositor']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  totalAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  depositCount?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  deposits?: Resolver<Maybe<Array<ResolversTypes['Deposit']>>, ParentType, ContextType, RequireFields<DepositordepositsArgs, 'skip' | 'first'>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -9142,9 +9142,15 @@ export type WrapResolvers<ContextType = MeshContext, ParentType extends Resolver
 export type Resolvers<ContextType = MeshContext> = ResolversObject<{
   Query?: QueryResolvers<ContextType>;
   Subscription?: SubscriptionResolvers<ContextType>;
+  Aggregation?: AggregationResolvers<ContextType>;
   BigDecimal?: GraphQLScalarType;
   BigInt?: GraphQLScalarType;
   Bytes?: GraphQLScalarType;
+  DailyDeposit?: DailyDepositResolvers<ContextType>;
+  Deposit?: DepositResolvers<ContextType>;
+  Depositor?: DepositorResolvers<ContextType>;
+  _Block_?: _Block_Resolvers<ContextType>;
+  _Meta_?: _Meta_Resolvers<ContextType>;
   Delegate?: DelegateResolvers<ContextType>;
   DelegateChange?: DelegateChangeResolvers<ContextType>;
   DelegateVotingPowerChange?: DelegateVotingPowerChangeResolvers<ContextType>;
@@ -9155,12 +9161,6 @@ export type Resolvers<ContextType = MeshContext> = ResolversObject<{
   TokenHolder?: TokenHolderResolvers<ContextType>;
   Vote?: VoteResolvers<ContextType>;
   VoteDailySnapshot?: VoteDailySnapshotResolvers<ContextType>;
-  _Block_?: _Block_Resolvers<ContextType>;
-  _Meta_?: _Meta_Resolvers<ContextType>;
-  Aggregation?: AggregationResolvers<ContextType>;
-  DailyDeposit?: DailyDepositResolvers<ContextType>;
-  Deposit?: DepositResolvers<ContextType>;
-  Depositor?: DepositorResolvers<ContextType>;
   Account?: AccountResolvers<ContextType>;
   Ask?: AskResolvers<ContextType>;
   AskCreated?: AskCreatedResolvers<ContextType>;
@@ -9192,7 +9192,7 @@ export type DirectiveResolvers<ContextType = MeshContext> = ResolversObject<{
   derivedFrom?: derivedFromDirectiveResolver<any, any, ContextType>;
 }>;
 
-export type MeshContext = EnsGovernanceTypes.Context & BeaconDepositorsTypes.Context & CryptopunksTypes.Context & BaseMeshContext;
+export type MeshContext = BeaconDepositorsTypes.Context & EnsGovernanceTypes.Context & CryptopunksTypes.Context & BaseMeshContext;
 
 
 const baseDir = pathModule.join(typeof __dirname === 'string' ? __dirname : '/', '..');
@@ -9200,11 +9200,11 @@ const baseDir = pathModule.join(typeof __dirname === 'string' ? __dirname : '/',
 const importFn: ImportFn = <T>(moduleId: string) => {
   const relativeModuleId = (pathModule.isAbsolute(moduleId) ? pathModule.relative(baseDir, moduleId) : moduleId).split('\\').join('/').replace(baseDir + '/', '');
   switch(relativeModuleId) {
-    case ".graphclient/sources/ens-governance/introspectionSchema":
-      return import("./sources/ens-governance/introspectionSchema") as T;
-    
     case ".graphclient/sources/beacon-depositors/introspectionSchema":
       return import("./sources/beacon-depositors/introspectionSchema") as T;
+    
+    case ".graphclient/sources/ens-governance/introspectionSchema":
+      return import("./sources/ens-governance/introspectionSchema") as T;
     
     case ".graphclient/sources/cryptopunks/introspectionSchema":
       return import("./sources/cryptopunks/introspectionSchema") as T;
@@ -9364,7 +9364,9 @@ export function getBuiltGraphSDK<TGlobalContext = any, TOperationContext = any>(
   const sdkRequester$ = getBuiltGraphClient().then(({ sdkRequesterFactory }) => sdkRequesterFactory(globalContext));
   return getSdk<TOperationContext, TGlobalContext>((...args) => sdkRequester$.then(sdkRequester => sdkRequester(...args)));
 }
-export type BeaconDepositorsQueryVariables = Exact<{ [key: string]: never; }>;
+export type BeaconDepositorsQueryVariables = Exact<{
+  skip?: InputMaybe<Scalars['Int']>;
+}>;
 
 
 export type BeaconDepositorsQuery = { depositors: Array<Pick<Depositor, 'id'>> };
@@ -9389,8 +9391,8 @@ export type PunkOwnersQuery = { punks: Array<{ owner: Pick<Account, 'id'> }> };
 
 
 export const BeaconDepositorsDocument = gql`
-    query BeaconDepositors {
-  depositors {
+    query BeaconDepositors($skip: Int) {
+  depositors(skip: $skip) {
     id
   }
 }

--- a/apis/query/src/lib/graph/.graphclient/index.ts
+++ b/apis/query/src/lib/graph/.graphclient/index.ts
@@ -21,8 +21,8 @@ import { MeshStore, FsStoreStorageAdapter } from '@graphql-mesh/store';
 import { path as pathModule } from '@graphql-mesh/cross-helpers';
 import { ImportFn } from '@graphql-mesh/types';
 import type { BeaconDepositorsTypes } from './sources/beacon-depositors/types';
-import type { CryptopunksTypes } from './sources/cryptopunks/types';
 import type { EnsGovernanceTypes } from './sources/ens-governance/types';
+import type { CryptopunksTypes } from './sources/cryptopunks/types';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -45,16 +45,6 @@ export type Scalars = {
 };
 
 export type Query = {
-  aggregation?: Maybe<Aggregation>;
-  aggregations: Array<Aggregation>;
-  depositor?: Maybe<Depositor>;
-  depositors: Array<Depositor>;
-  dailyDeposit?: Maybe<DailyDeposit>;
-  dailyDeposits: Array<DailyDeposit>;
-  deposit?: Maybe<Deposit>;
-  deposits: Array<Deposit>;
-  /** Access to subgraph metadata */
-  _meta?: Maybe<_Meta_>;
   delegateChange?: Maybe<DelegateChange>;
   delegateChanges: Array<DelegateChange>;
   delegateVotingPowerChange?: Maybe<DelegateVotingPowerChange>;
@@ -75,6 +65,16 @@ export type Query = {
   tokenDailySnapshots: Array<TokenDailySnapshot>;
   voteDailySnapshot?: Maybe<VoteDailySnapshot>;
   voteDailySnapshots: Array<VoteDailySnapshot>;
+  /** Access to subgraph metadata */
+  _meta?: Maybe<_Meta_>;
+  aggregation?: Maybe<Aggregation>;
+  aggregations: Array<Aggregation>;
+  depositor?: Maybe<Depositor>;
+  depositors: Array<Depositor>;
+  dailyDeposit?: Maybe<DailyDeposit>;
+  dailyDeposits: Array<DailyDeposit>;
+  deposit?: Maybe<Deposit>;
+  deposits: Array<Deposit>;
   account?: Maybe<Account>;
   accounts: Array<Account>;
   punk?: Maybe<Punk>;
@@ -121,83 +121,6 @@ export type Query = {
   events: Array<Event>;
   offer?: Maybe<Offer>;
   offers: Array<Offer>;
-};
-
-
-export type QueryaggregationArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QueryaggregationsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Aggregation_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Aggregation_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydepositorArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydepositorsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Depositor_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Depositor_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydailyDepositArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydailyDepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<DailyDeposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<DailyDeposit_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydepositArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type QuerydepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Deposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Deposit_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type Query_metaArgs = {
-  block?: InputMaybe<Block_height>;
 };
 
 
@@ -376,6 +299,83 @@ export type QueryvoteDailySnapshotsArgs = {
   orderBy?: InputMaybe<VoteDailySnapshot_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<VoteDailySnapshot_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type Query_metaArgs = {
+  block?: InputMaybe<Block_height>;
+};
+
+
+export type QueryaggregationArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryaggregationsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Aggregation_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Aggregation_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydepositorArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydepositorsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Depositor_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Depositor_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydailyDepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydailyDepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<DailyDeposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<DailyDeposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QuerydepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Deposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Deposit_filter>;
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
@@ -795,16 +795,6 @@ export type QueryoffersArgs = {
 };
 
 export type Subscription = {
-  aggregation?: Maybe<Aggregation>;
-  aggregations: Array<Aggregation>;
-  depositor?: Maybe<Depositor>;
-  depositors: Array<Depositor>;
-  dailyDeposit?: Maybe<DailyDeposit>;
-  dailyDeposits: Array<DailyDeposit>;
-  deposit?: Maybe<Deposit>;
-  deposits: Array<Deposit>;
-  /** Access to subgraph metadata */
-  _meta?: Maybe<_Meta_>;
   delegateChange?: Maybe<DelegateChange>;
   delegateChanges: Array<DelegateChange>;
   delegateVotingPowerChange?: Maybe<DelegateVotingPowerChange>;
@@ -825,6 +815,16 @@ export type Subscription = {
   tokenDailySnapshots: Array<TokenDailySnapshot>;
   voteDailySnapshot?: Maybe<VoteDailySnapshot>;
   voteDailySnapshots: Array<VoteDailySnapshot>;
+  /** Access to subgraph metadata */
+  _meta?: Maybe<_Meta_>;
+  aggregation?: Maybe<Aggregation>;
+  aggregations: Array<Aggregation>;
+  depositor?: Maybe<Depositor>;
+  depositors: Array<Depositor>;
+  dailyDeposit?: Maybe<DailyDeposit>;
+  dailyDeposits: Array<DailyDeposit>;
+  deposit?: Maybe<Deposit>;
+  deposits: Array<Deposit>;
   account?: Maybe<Account>;
   accounts: Array<Account>;
   punk?: Maybe<Punk>;
@@ -871,83 +871,6 @@ export type Subscription = {
   events: Array<Event>;
   offer?: Maybe<Offer>;
   offers: Array<Offer>;
-};
-
-
-export type SubscriptionaggregationArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptionaggregationsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Aggregation_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Aggregation_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondepositorArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondepositorsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Depositor_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Depositor_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondailyDepositArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondailyDepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<DailyDeposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<DailyDeposit_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondepositArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptiondepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Deposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Deposit_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type Subscription_metaArgs = {
-  block?: InputMaybe<Block_height>;
 };
 
 
@@ -1126,6 +1049,83 @@ export type SubscriptionvoteDailySnapshotsArgs = {
   orderBy?: InputMaybe<VoteDailySnapshot_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<VoteDailySnapshot_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type Subscription_metaArgs = {
+  block?: InputMaybe<Block_height>;
+};
+
+
+export type SubscriptionaggregationArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionaggregationsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Aggregation_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Aggregation_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondepositorArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondepositorsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Depositor_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Depositor_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondailyDepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondailyDepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<DailyDeposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<DailyDeposit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondepositArgs = {
+  id: Scalars['ID'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptiondepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Deposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Deposit_filter>;
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
@@ -1544,58 +1544,6 @@ export type SubscriptionoffersArgs = {
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-export type Aggregation = {
-  id: Scalars['ID'];
-  totalDeposits?: Maybe<Scalars['BigInt']>;
-  totalDepositors?: Maybe<Scalars['BigInt']>;
-  totalAmountDeposited?: Maybe<Scalars['BigInt']>;
-};
-
-export type Aggregation_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  totalDeposits?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_not?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_gt?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_lt?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_gte?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_lte?: InputMaybe<Scalars['BigInt']>;
-  totalDeposits_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalDeposits_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalDepositors?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_not?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_gt?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_lt?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_gte?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_lte?: InputMaybe<Scalars['BigInt']>;
-  totalDepositors_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalDepositors_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalAmountDeposited?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
-};
-
-export type Aggregation_orderBy =
-  | 'id'
-  | 'totalDeposits'
-  | 'totalDepositors'
-  | 'totalAmountDeposited';
-
 export type BlockChangedFilter = {
   number_gte: Scalars['Int'];
 };
@@ -1605,252 +1553,6 @@ export type Block_height = {
   number?: InputMaybe<Scalars['Int']>;
   number_gte?: InputMaybe<Scalars['Int']>;
 };
-
-export type DailyDeposit = {
-  id: Scalars['ID'];
-  dailyAmountDeposited?: Maybe<Scalars['BigInt']>;
-  dailyDepositCount?: Maybe<Scalars['BigInt']>;
-};
-
-export type DailyDeposit_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  dailyAmountDeposited?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
-  dailyAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  dailyAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  dailyDepositCount?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_not?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_gt?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_lt?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_gte?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_lte?: InputMaybe<Scalars['BigInt']>;
-  dailyDepositCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  dailyDepositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
-};
-
-export type DailyDeposit_orderBy =
-  | 'id'
-  | 'dailyAmountDeposited'
-  | 'dailyDepositCount';
-
-export type Deposit = {
-  id: Scalars['ID'];
-  dayID: Scalars['String'];
-  depositor?: Maybe<Depositor>;
-  pubkey: Scalars['Bytes'];
-  withdrawal_credentials: Scalars['Bytes'];
-  amount: Scalars['BigInt'];
-  timestamp: Scalars['BigInt'];
-};
-
-export type Deposit_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  dayID?: InputMaybe<Scalars['String']>;
-  dayID_not?: InputMaybe<Scalars['String']>;
-  dayID_gt?: InputMaybe<Scalars['String']>;
-  dayID_lt?: InputMaybe<Scalars['String']>;
-  dayID_gte?: InputMaybe<Scalars['String']>;
-  dayID_lte?: InputMaybe<Scalars['String']>;
-  dayID_in?: InputMaybe<Array<Scalars['String']>>;
-  dayID_not_in?: InputMaybe<Array<Scalars['String']>>;
-  dayID_contains?: InputMaybe<Scalars['String']>;
-  dayID_contains_nocase?: InputMaybe<Scalars['String']>;
-  dayID_not_contains?: InputMaybe<Scalars['String']>;
-  dayID_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  dayID_starts_with?: InputMaybe<Scalars['String']>;
-  dayID_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  dayID_not_starts_with?: InputMaybe<Scalars['String']>;
-  dayID_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  dayID_ends_with?: InputMaybe<Scalars['String']>;
-  dayID_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  dayID_not_ends_with?: InputMaybe<Scalars['String']>;
-  dayID_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor?: InputMaybe<Scalars['String']>;
-  depositor_not?: InputMaybe<Scalars['String']>;
-  depositor_gt?: InputMaybe<Scalars['String']>;
-  depositor_lt?: InputMaybe<Scalars['String']>;
-  depositor_gte?: InputMaybe<Scalars['String']>;
-  depositor_lte?: InputMaybe<Scalars['String']>;
-  depositor_in?: InputMaybe<Array<Scalars['String']>>;
-  depositor_not_in?: InputMaybe<Array<Scalars['String']>>;
-  depositor_contains?: InputMaybe<Scalars['String']>;
-  depositor_contains_nocase?: InputMaybe<Scalars['String']>;
-  depositor_not_contains?: InputMaybe<Scalars['String']>;
-  depositor_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  depositor_starts_with?: InputMaybe<Scalars['String']>;
-  depositor_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor_not_starts_with?: InputMaybe<Scalars['String']>;
-  depositor_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor_ends_with?: InputMaybe<Scalars['String']>;
-  depositor_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor_not_ends_with?: InputMaybe<Scalars['String']>;
-  depositor_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  depositor_?: InputMaybe<Depositor_filter>;
-  pubkey?: InputMaybe<Scalars['Bytes']>;
-  pubkey_not?: InputMaybe<Scalars['Bytes']>;
-  pubkey_gt?: InputMaybe<Scalars['Bytes']>;
-  pubkey_lt?: InputMaybe<Scalars['Bytes']>;
-  pubkey_gte?: InputMaybe<Scalars['Bytes']>;
-  pubkey_lte?: InputMaybe<Scalars['Bytes']>;
-  pubkey_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  pubkey_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  pubkey_contains?: InputMaybe<Scalars['Bytes']>;
-  pubkey_not_contains?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_not?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_gt?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_lt?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_gte?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_lte?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  withdrawal_credentials_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  withdrawal_credentials_contains?: InputMaybe<Scalars['Bytes']>;
-  withdrawal_credentials_not_contains?: InputMaybe<Scalars['Bytes']>;
-  amount?: InputMaybe<Scalars['BigInt']>;
-  amount_not?: InputMaybe<Scalars['BigInt']>;
-  amount_gt?: InputMaybe<Scalars['BigInt']>;
-  amount_lt?: InputMaybe<Scalars['BigInt']>;
-  amount_gte?: InputMaybe<Scalars['BigInt']>;
-  amount_lte?: InputMaybe<Scalars['BigInt']>;
-  amount_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  amount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  timestamp?: InputMaybe<Scalars['BigInt']>;
-  timestamp_not?: InputMaybe<Scalars['BigInt']>;
-  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
-  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
-  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
-  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
-  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
-};
-
-export type Deposit_orderBy =
-  | 'id'
-  | 'dayID'
-  | 'depositor'
-  | 'depositor__id'
-  | 'depositor__totalAmountDeposited'
-  | 'depositor__depositCount'
-  | 'pubkey'
-  | 'withdrawal_credentials'
-  | 'amount'
-  | 'timestamp';
-
-export type Depositor = {
-  id: Scalars['ID'];
-  totalAmountDeposited?: Maybe<Scalars['BigInt']>;
-  depositCount?: Maybe<Scalars['BigInt']>;
-  deposits?: Maybe<Array<Deposit>>;
-};
-
-
-export type DepositordepositsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Deposit_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Deposit_filter>;
-};
-
-export type Depositor_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  totalAmountDeposited?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
-  totalAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  depositCount?: InputMaybe<Scalars['BigInt']>;
-  depositCount_not?: InputMaybe<Scalars['BigInt']>;
-  depositCount_gt?: InputMaybe<Scalars['BigInt']>;
-  depositCount_lt?: InputMaybe<Scalars['BigInt']>;
-  depositCount_gte?: InputMaybe<Scalars['BigInt']>;
-  depositCount_lte?: InputMaybe<Scalars['BigInt']>;
-  depositCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  depositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  deposits_?: InputMaybe<Deposit_filter>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
-};
-
-export type Depositor_orderBy =
-  | 'id'
-  | 'totalAmountDeposited'
-  | 'depositCount'
-  | 'deposits';
-
-/** Defines the order direction, either ascending or descending */
-export type OrderDirection =
-  | 'asc'
-  | 'desc';
-
-export type _Block_ = {
-  /** The hash of the block */
-  hash?: Maybe<Scalars['Bytes']>;
-  /** The block number */
-  number: Scalars['Int'];
-  /** Integer representation of the timestamp stored in blocks for the chain */
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** The type for the top-level _meta field */
-export type _Meta_ = {
-  /**
-   * Information about a specific subgraph block. The hash of the block
-   * will be null if the _meta field has a block constraint that asks for
-   * a block number. It will be filled if the _meta field has no block constraint
-   * and therefore asks for the latest  block
-   *
-   */
-  block: _Block_;
-  /** The deployment ID */
-  deployment: Scalars['String'];
-  /** If `true`, the subgraph encountered indexing errors at some past block */
-  hasIndexingErrors: Scalars['Boolean'];
-};
-
-export type _SubgraphErrorPolicy_ =
-  /** Data will be returned even if the subgraph has indexing errors */
-  | 'allow'
-  /** If the subgraph has indexing errors, data will be omitted. The default. */
-  | 'deny';
 
 export type Delegate = {
   /** A Delegate is any address that has been delegated with voting tokens by a token holder, id is the blockchain address of said delegate */
@@ -2649,6 +2351,11 @@ export type Governance_orderBy =
   | 'proposalsQueued'
   | 'proposalsExecuted'
   | 'proposalsCanceled';
+
+/** Defines the order direction, either ascending or descending */
+export type OrderDirection =
+  | 'asc'
+  | 'desc';
 
 export type Proposal = {
   /** Internal proposal ID, in this implementation it seems to be a autoincremental id */
@@ -3589,6 +3296,299 @@ export type Vote_orderBy =
   | 'block'
   | 'blockTime'
   | 'txnHash';
+
+export type _Block_ = {
+  /** The hash of the block */
+  hash?: Maybe<Scalars['Bytes']>;
+  /** The block number */
+  number: Scalars['Int'];
+  /** Integer representation of the timestamp stored in blocks for the chain */
+  timestamp?: Maybe<Scalars['Int']>;
+};
+
+/** The type for the top-level _meta field */
+export type _Meta_ = {
+  /**
+   * Information about a specific subgraph block. The hash of the block
+   * will be null if the _meta field has a block constraint that asks for
+   * a block number. It will be filled if the _meta field has no block constraint
+   * and therefore asks for the latest  block
+   *
+   */
+  block: _Block_;
+  /** The deployment ID */
+  deployment: Scalars['String'];
+  /** If `true`, the subgraph encountered indexing errors at some past block */
+  hasIndexingErrors: Scalars['Boolean'];
+};
+
+export type _SubgraphErrorPolicy_ =
+  /** Data will be returned even if the subgraph has indexing errors */
+  | 'allow'
+  /** If the subgraph has indexing errors, data will be omitted. The default. */
+  | 'deny';
+
+export type Aggregation = {
+  id: Scalars['ID'];
+  totalDeposits?: Maybe<Scalars['BigInt']>;
+  totalDepositors?: Maybe<Scalars['BigInt']>;
+  totalAmountDeposited?: Maybe<Scalars['BigInt']>;
+};
+
+export type Aggregation_filter = {
+  id?: InputMaybe<Scalars['ID']>;
+  id_not?: InputMaybe<Scalars['ID']>;
+  id_gt?: InputMaybe<Scalars['ID']>;
+  id_lt?: InputMaybe<Scalars['ID']>;
+  id_gte?: InputMaybe<Scalars['ID']>;
+  id_lte?: InputMaybe<Scalars['ID']>;
+  id_in?: InputMaybe<Array<Scalars['ID']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  totalDeposits?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_not?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_gt?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_lt?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_gte?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_lte?: InputMaybe<Scalars['BigInt']>;
+  totalDeposits_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalDeposits_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalDepositors?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_not?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_gt?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_lt?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_gte?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_lte?: InputMaybe<Scalars['BigInt']>;
+  totalDepositors_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalDepositors_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalAmountDeposited?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
+};
+
+export type Aggregation_orderBy =
+  | 'id'
+  | 'totalDeposits'
+  | 'totalDepositors'
+  | 'totalAmountDeposited';
+
+export type DailyDeposit = {
+  id: Scalars['ID'];
+  dailyAmountDeposited?: Maybe<Scalars['BigInt']>;
+  dailyDepositCount?: Maybe<Scalars['BigInt']>;
+};
+
+export type DailyDeposit_filter = {
+  id?: InputMaybe<Scalars['ID']>;
+  id_not?: InputMaybe<Scalars['ID']>;
+  id_gt?: InputMaybe<Scalars['ID']>;
+  id_lt?: InputMaybe<Scalars['ID']>;
+  id_gte?: InputMaybe<Scalars['ID']>;
+  id_lte?: InputMaybe<Scalars['ID']>;
+  id_in?: InputMaybe<Array<Scalars['ID']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  dailyAmountDeposited?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
+  dailyAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  dailyAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  dailyDepositCount?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_not?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_gt?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_lt?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_gte?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_lte?: InputMaybe<Scalars['BigInt']>;
+  dailyDepositCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  dailyDepositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
+};
+
+export type DailyDeposit_orderBy =
+  | 'id'
+  | 'dailyAmountDeposited'
+  | 'dailyDepositCount';
+
+export type Deposit = {
+  id: Scalars['ID'];
+  dayID: Scalars['String'];
+  depositor?: Maybe<Depositor>;
+  pubkey: Scalars['Bytes'];
+  withdrawal_credentials: Scalars['Bytes'];
+  amount: Scalars['BigInt'];
+  timestamp: Scalars['BigInt'];
+};
+
+export type Deposit_filter = {
+  id?: InputMaybe<Scalars['ID']>;
+  id_not?: InputMaybe<Scalars['ID']>;
+  id_gt?: InputMaybe<Scalars['ID']>;
+  id_lt?: InputMaybe<Scalars['ID']>;
+  id_gte?: InputMaybe<Scalars['ID']>;
+  id_lte?: InputMaybe<Scalars['ID']>;
+  id_in?: InputMaybe<Array<Scalars['ID']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  dayID?: InputMaybe<Scalars['String']>;
+  dayID_not?: InputMaybe<Scalars['String']>;
+  dayID_gt?: InputMaybe<Scalars['String']>;
+  dayID_lt?: InputMaybe<Scalars['String']>;
+  dayID_gte?: InputMaybe<Scalars['String']>;
+  dayID_lte?: InputMaybe<Scalars['String']>;
+  dayID_in?: InputMaybe<Array<Scalars['String']>>;
+  dayID_not_in?: InputMaybe<Array<Scalars['String']>>;
+  dayID_contains?: InputMaybe<Scalars['String']>;
+  dayID_contains_nocase?: InputMaybe<Scalars['String']>;
+  dayID_not_contains?: InputMaybe<Scalars['String']>;
+  dayID_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  dayID_starts_with?: InputMaybe<Scalars['String']>;
+  dayID_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  dayID_not_starts_with?: InputMaybe<Scalars['String']>;
+  dayID_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  dayID_ends_with?: InputMaybe<Scalars['String']>;
+  dayID_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  dayID_not_ends_with?: InputMaybe<Scalars['String']>;
+  dayID_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor?: InputMaybe<Scalars['String']>;
+  depositor_not?: InputMaybe<Scalars['String']>;
+  depositor_gt?: InputMaybe<Scalars['String']>;
+  depositor_lt?: InputMaybe<Scalars['String']>;
+  depositor_gte?: InputMaybe<Scalars['String']>;
+  depositor_lte?: InputMaybe<Scalars['String']>;
+  depositor_in?: InputMaybe<Array<Scalars['String']>>;
+  depositor_not_in?: InputMaybe<Array<Scalars['String']>>;
+  depositor_contains?: InputMaybe<Scalars['String']>;
+  depositor_contains_nocase?: InputMaybe<Scalars['String']>;
+  depositor_not_contains?: InputMaybe<Scalars['String']>;
+  depositor_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  depositor_starts_with?: InputMaybe<Scalars['String']>;
+  depositor_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor_not_starts_with?: InputMaybe<Scalars['String']>;
+  depositor_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor_ends_with?: InputMaybe<Scalars['String']>;
+  depositor_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor_not_ends_with?: InputMaybe<Scalars['String']>;
+  depositor_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  depositor_?: InputMaybe<Depositor_filter>;
+  pubkey?: InputMaybe<Scalars['Bytes']>;
+  pubkey_not?: InputMaybe<Scalars['Bytes']>;
+  pubkey_gt?: InputMaybe<Scalars['Bytes']>;
+  pubkey_lt?: InputMaybe<Scalars['Bytes']>;
+  pubkey_gte?: InputMaybe<Scalars['Bytes']>;
+  pubkey_lte?: InputMaybe<Scalars['Bytes']>;
+  pubkey_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  pubkey_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  pubkey_contains?: InputMaybe<Scalars['Bytes']>;
+  pubkey_not_contains?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_not?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_gt?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_lt?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_gte?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_lte?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  withdrawal_credentials_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
+  withdrawal_credentials_contains?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_not_contains?: InputMaybe<Scalars['Bytes']>;
+  amount?: InputMaybe<Scalars['BigInt']>;
+  amount_not?: InputMaybe<Scalars['BigInt']>;
+  amount_gt?: InputMaybe<Scalars['BigInt']>;
+  amount_lt?: InputMaybe<Scalars['BigInt']>;
+  amount_gte?: InputMaybe<Scalars['BigInt']>;
+  amount_lte?: InputMaybe<Scalars['BigInt']>;
+  amount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  amount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp?: InputMaybe<Scalars['BigInt']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
+};
+
+export type Deposit_orderBy =
+  | 'id'
+  | 'dayID'
+  | 'depositor'
+  | 'depositor__id'
+  | 'depositor__totalAmountDeposited'
+  | 'depositor__depositCount'
+  | 'pubkey'
+  | 'withdrawal_credentials'
+  | 'amount'
+  | 'timestamp';
+
+export type Depositor = {
+  id: Scalars['ID'];
+  totalAmountDeposited?: Maybe<Scalars['BigInt']>;
+  depositCount?: Maybe<Scalars['BigInt']>;
+  deposits?: Maybe<Array<Deposit>>;
+};
+
+
+export type DepositordepositsArgs = {
+  skip?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Deposit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Deposit_filter>;
+};
+
+export type Depositor_filter = {
+  id?: InputMaybe<Scalars['ID']>;
+  id_not?: InputMaybe<Scalars['ID']>;
+  id_gt?: InputMaybe<Scalars['ID']>;
+  id_lt?: InputMaybe<Scalars['ID']>;
+  id_gte?: InputMaybe<Scalars['ID']>;
+  id_lte?: InputMaybe<Scalars['ID']>;
+  id_in?: InputMaybe<Array<Scalars['ID']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
+  totalAmountDeposited?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_not?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_gt?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_lt?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_gte?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_lte?: InputMaybe<Scalars['BigInt']>;
+  totalAmountDeposited_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  depositCount?: InputMaybe<Scalars['BigInt']>;
+  depositCount_not?: InputMaybe<Scalars['BigInt']>;
+  depositCount_gt?: InputMaybe<Scalars['BigInt']>;
+  depositCount_lt?: InputMaybe<Scalars['BigInt']>;
+  depositCount_gte?: InputMaybe<Scalars['BigInt']>;
+  depositCount_lte?: InputMaybe<Scalars['BigInt']>;
+  depositCount_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  depositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  deposits_?: InputMaybe<Deposit_filter>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
+};
+
+export type Depositor_orderBy =
+  | 'id'
+  | 'totalAmountDeposited'
+  | 'depositCount'
+  | 'deposits';
 
 export type Account = {
   /** Ethereum Address */
@@ -8197,32 +8197,12 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversTypes = ResolversObject<{
   Query: ResolverTypeWrapper<{}>;
   Subscription: ResolverTypeWrapper<{}>;
-  Aggregation: ResolverTypeWrapper<Aggregation>;
-  Aggregation_filter: Aggregation_filter;
-  Aggregation_orderBy: Aggregation_orderBy;
   BigDecimal: ResolverTypeWrapper<Scalars['BigDecimal']>;
   BigInt: ResolverTypeWrapper<Scalars['BigInt']>;
   BlockChangedFilter: BlockChangedFilter;
   Block_height: Block_height;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   Bytes: ResolverTypeWrapper<Scalars['Bytes']>;
-  DailyDeposit: ResolverTypeWrapper<DailyDeposit>;
-  DailyDeposit_filter: DailyDeposit_filter;
-  DailyDeposit_orderBy: DailyDeposit_orderBy;
-  Deposit: ResolverTypeWrapper<Deposit>;
-  Deposit_filter: Deposit_filter;
-  Deposit_orderBy: Deposit_orderBy;
-  Depositor: ResolverTypeWrapper<Depositor>;
-  Depositor_filter: Depositor_filter;
-  Depositor_orderBy: Depositor_orderBy;
-  Float: ResolverTypeWrapper<Scalars['Float']>;
-  ID: ResolverTypeWrapper<Scalars['ID']>;
-  Int: ResolverTypeWrapper<Scalars['Int']>;
-  OrderDirection: OrderDirection;
-  String: ResolverTypeWrapper<Scalars['String']>;
-  _Block_: ResolverTypeWrapper<_Block_>;
-  _Meta_: ResolverTypeWrapper<_Meta_>;
-  _SubgraphErrorPolicy_: _SubgraphErrorPolicy_;
   Delegate: ResolverTypeWrapper<Delegate>;
   DelegateChange: ResolverTypeWrapper<DelegateChange>;
   DelegateChange_filter: DelegateChange_filter;
@@ -8232,6 +8212,7 @@ export type ResolversTypes = ResolversObject<{
   DelegateVotingPowerChange_orderBy: DelegateVotingPowerChange_orderBy;
   Delegate_filter: Delegate_filter;
   Delegate_orderBy: Delegate_orderBy;
+  Float: ResolverTypeWrapper<Scalars['Float']>;
   Governance: ResolverTypeWrapper<Governance>;
   GovernanceFramework: ResolverTypeWrapper<GovernanceFramework>;
   GovernanceFrameworkType: GovernanceFrameworkType;
@@ -8239,10 +8220,14 @@ export type ResolversTypes = ResolversObject<{
   GovernanceFramework_orderBy: GovernanceFramework_orderBy;
   Governance_filter: Governance_filter;
   Governance_orderBy: Governance_orderBy;
+  ID: ResolverTypeWrapper<Scalars['ID']>;
+  Int: ResolverTypeWrapper<Scalars['Int']>;
+  OrderDirection: OrderDirection;
   Proposal: ResolverTypeWrapper<Proposal>;
   ProposalState: ProposalState;
   Proposal_filter: Proposal_filter;
   Proposal_orderBy: Proposal_orderBy;
+  String: ResolverTypeWrapper<Scalars['String']>;
   TokenDailySnapshot: ResolverTypeWrapper<TokenDailySnapshot>;
   TokenDailySnapshot_filter: TokenDailySnapshot_filter;
   TokenDailySnapshot_orderBy: TokenDailySnapshot_orderBy;
@@ -8256,6 +8241,21 @@ export type ResolversTypes = ResolversObject<{
   VoteDailySnapshot_orderBy: VoteDailySnapshot_orderBy;
   Vote_filter: Vote_filter;
   Vote_orderBy: Vote_orderBy;
+  _Block_: ResolverTypeWrapper<_Block_>;
+  _Meta_: ResolverTypeWrapper<_Meta_>;
+  _SubgraphErrorPolicy_: _SubgraphErrorPolicy_;
+  Aggregation: ResolverTypeWrapper<Aggregation>;
+  Aggregation_filter: Aggregation_filter;
+  Aggregation_orderBy: Aggregation_orderBy;
+  DailyDeposit: ResolverTypeWrapper<DailyDeposit>;
+  DailyDeposit_filter: DailyDeposit_filter;
+  DailyDeposit_orderBy: DailyDeposit_orderBy;
+  Deposit: ResolverTypeWrapper<Deposit>;
+  Deposit_filter: Deposit_filter;
+  Deposit_orderBy: Deposit_orderBy;
+  Depositor: ResolverTypeWrapper<Depositor>;
+  Depositor_filter: Depositor_filter;
+  Depositor_orderBy: Depositor_orderBy;
   Account: ResolverTypeWrapper<Account>;
   Account_filter: Account_filter;
   Account_orderBy: Account_orderBy;
@@ -8334,38 +8334,28 @@ export type ResolversTypes = ResolversObject<{
 export type ResolversParentTypes = ResolversObject<{
   Query: {};
   Subscription: {};
-  Aggregation: Aggregation;
-  Aggregation_filter: Aggregation_filter;
   BigDecimal: Scalars['BigDecimal'];
   BigInt: Scalars['BigInt'];
   BlockChangedFilter: BlockChangedFilter;
   Block_height: Block_height;
   Boolean: Scalars['Boolean'];
   Bytes: Scalars['Bytes'];
-  DailyDeposit: DailyDeposit;
-  DailyDeposit_filter: DailyDeposit_filter;
-  Deposit: Deposit;
-  Deposit_filter: Deposit_filter;
-  Depositor: Depositor;
-  Depositor_filter: Depositor_filter;
-  Float: Scalars['Float'];
-  ID: Scalars['ID'];
-  Int: Scalars['Int'];
-  String: Scalars['String'];
-  _Block_: _Block_;
-  _Meta_: _Meta_;
   Delegate: Delegate;
   DelegateChange: DelegateChange;
   DelegateChange_filter: DelegateChange_filter;
   DelegateVotingPowerChange: DelegateVotingPowerChange;
   DelegateVotingPowerChange_filter: DelegateVotingPowerChange_filter;
   Delegate_filter: Delegate_filter;
+  Float: Scalars['Float'];
   Governance: Governance;
   GovernanceFramework: GovernanceFramework;
   GovernanceFramework_filter: GovernanceFramework_filter;
   Governance_filter: Governance_filter;
+  ID: Scalars['ID'];
+  Int: Scalars['Int'];
   Proposal: Proposal;
   Proposal_filter: Proposal_filter;
+  String: Scalars['String'];
   TokenDailySnapshot: TokenDailySnapshot;
   TokenDailySnapshot_filter: TokenDailySnapshot_filter;
   TokenHolder: TokenHolder;
@@ -8374,6 +8364,16 @@ export type ResolversParentTypes = ResolversObject<{
   VoteDailySnapshot: VoteDailySnapshot;
   VoteDailySnapshot_filter: VoteDailySnapshot_filter;
   Vote_filter: Vote_filter;
+  _Block_: _Block_;
+  _Meta_: _Meta_;
+  Aggregation: Aggregation;
+  Aggregation_filter: Aggregation_filter;
+  DailyDeposit: DailyDeposit;
+  DailyDeposit_filter: DailyDeposit_filter;
+  Deposit: Deposit;
+  Deposit_filter: Deposit_filter;
+  Depositor: Depositor;
+  Depositor_filter: Depositor_filter;
   Account: Account;
   Account_filter: Account_filter;
   Ask: Ask;
@@ -8439,15 +8439,6 @@ export type derivedFromDirectiveArgs = {
 export type derivedFromDirectiveResolver<Result, Parent, ContextType = MeshContext, Args = derivedFromDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type QueryResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
-  aggregation?: Resolver<Maybe<ResolversTypes['Aggregation']>, ParentType, ContextType, RequireFields<QueryaggregationArgs, 'id' | 'subgraphError'>>;
-  aggregations?: Resolver<Array<ResolversTypes['Aggregation']>, ParentType, ContextType, RequireFields<QueryaggregationsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  depositor?: Resolver<Maybe<ResolversTypes['Depositor']>, ParentType, ContextType, RequireFields<QuerydepositorArgs, 'id' | 'subgraphError'>>;
-  depositors?: Resolver<Array<ResolversTypes['Depositor']>, ParentType, ContextType, RequireFields<QuerydepositorsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  dailyDeposit?: Resolver<Maybe<ResolversTypes['DailyDeposit']>, ParentType, ContextType, RequireFields<QuerydailyDepositArgs, 'id' | 'subgraphError'>>;
-  dailyDeposits?: Resolver<Array<ResolversTypes['DailyDeposit']>, ParentType, ContextType, RequireFields<QuerydailyDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  deposit?: Resolver<Maybe<ResolversTypes['Deposit']>, ParentType, ContextType, RequireFields<QuerydepositArgs, 'id' | 'subgraphError'>>;
-  deposits?: Resolver<Array<ResolversTypes['Deposit']>, ParentType, ContextType, RequireFields<QuerydepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  _meta?: Resolver<Maybe<ResolversTypes['_Meta_']>, ParentType, ContextType, Partial<Query_metaArgs>>;
   delegateChange?: Resolver<Maybe<ResolversTypes['DelegateChange']>, ParentType, ContextType, RequireFields<QuerydelegateChangeArgs, 'id' | 'subgraphError'>>;
   delegateChanges?: Resolver<Array<ResolversTypes['DelegateChange']>, ParentType, ContextType, RequireFields<QuerydelegateChangesArgs, 'skip' | 'first' | 'subgraphError'>>;
   delegateVotingPowerChange?: Resolver<Maybe<ResolversTypes['DelegateVotingPowerChange']>, ParentType, ContextType, RequireFields<QuerydelegateVotingPowerChangeArgs, 'id' | 'subgraphError'>>;
@@ -8468,6 +8459,15 @@ export type QueryResolvers<ContextType = MeshContext, ParentType extends Resolve
   tokenDailySnapshots?: Resolver<Array<ResolversTypes['TokenDailySnapshot']>, ParentType, ContextType, RequireFields<QuerytokenDailySnapshotsArgs, 'skip' | 'first' | 'subgraphError'>>;
   voteDailySnapshot?: Resolver<Maybe<ResolversTypes['VoteDailySnapshot']>, ParentType, ContextType, RequireFields<QueryvoteDailySnapshotArgs, 'id' | 'subgraphError'>>;
   voteDailySnapshots?: Resolver<Array<ResolversTypes['VoteDailySnapshot']>, ParentType, ContextType, RequireFields<QueryvoteDailySnapshotsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  _meta?: Resolver<Maybe<ResolversTypes['_Meta_']>, ParentType, ContextType, Partial<Query_metaArgs>>;
+  aggregation?: Resolver<Maybe<ResolversTypes['Aggregation']>, ParentType, ContextType, RequireFields<QueryaggregationArgs, 'id' | 'subgraphError'>>;
+  aggregations?: Resolver<Array<ResolversTypes['Aggregation']>, ParentType, ContextType, RequireFields<QueryaggregationsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  depositor?: Resolver<Maybe<ResolversTypes['Depositor']>, ParentType, ContextType, RequireFields<QuerydepositorArgs, 'id' | 'subgraphError'>>;
+  depositors?: Resolver<Array<ResolversTypes['Depositor']>, ParentType, ContextType, RequireFields<QuerydepositorsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  dailyDeposit?: Resolver<Maybe<ResolversTypes['DailyDeposit']>, ParentType, ContextType, RequireFields<QuerydailyDepositArgs, 'id' | 'subgraphError'>>;
+  dailyDeposits?: Resolver<Array<ResolversTypes['DailyDeposit']>, ParentType, ContextType, RequireFields<QuerydailyDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  deposit?: Resolver<Maybe<ResolversTypes['Deposit']>, ParentType, ContextType, RequireFields<QuerydepositArgs, 'id' | 'subgraphError'>>;
+  deposits?: Resolver<Array<ResolversTypes['Deposit']>, ParentType, ContextType, RequireFields<QuerydepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
   account?: Resolver<Maybe<ResolversTypes['Account']>, ParentType, ContextType, RequireFields<QueryaccountArgs, 'id' | 'subgraphError'>>;
   accounts?: Resolver<Array<ResolversTypes['Account']>, ParentType, ContextType, RequireFields<QueryaccountsArgs, 'skip' | 'first' | 'subgraphError'>>;
   punk?: Resolver<Maybe<ResolversTypes['Punk']>, ParentType, ContextType, RequireFields<QuerypunkArgs, 'id' | 'subgraphError'>>;
@@ -8517,15 +8517,6 @@ export type QueryResolvers<ContextType = MeshContext, ParentType extends Resolve
 }>;
 
 export type SubscriptionResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = ResolversObject<{
-  aggregation?: SubscriptionResolver<Maybe<ResolversTypes['Aggregation']>, "aggregation", ParentType, ContextType, RequireFields<SubscriptionaggregationArgs, 'id' | 'subgraphError'>>;
-  aggregations?: SubscriptionResolver<Array<ResolversTypes['Aggregation']>, "aggregations", ParentType, ContextType, RequireFields<SubscriptionaggregationsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  depositor?: SubscriptionResolver<Maybe<ResolversTypes['Depositor']>, "depositor", ParentType, ContextType, RequireFields<SubscriptiondepositorArgs, 'id' | 'subgraphError'>>;
-  depositors?: SubscriptionResolver<Array<ResolversTypes['Depositor']>, "depositors", ParentType, ContextType, RequireFields<SubscriptiondepositorsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  dailyDeposit?: SubscriptionResolver<Maybe<ResolversTypes['DailyDeposit']>, "dailyDeposit", ParentType, ContextType, RequireFields<SubscriptiondailyDepositArgs, 'id' | 'subgraphError'>>;
-  dailyDeposits?: SubscriptionResolver<Array<ResolversTypes['DailyDeposit']>, "dailyDeposits", ParentType, ContextType, RequireFields<SubscriptiondailyDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  deposit?: SubscriptionResolver<Maybe<ResolversTypes['Deposit']>, "deposit", ParentType, ContextType, RequireFields<SubscriptiondepositArgs, 'id' | 'subgraphError'>>;
-  deposits?: SubscriptionResolver<Array<ResolversTypes['Deposit']>, "deposits", ParentType, ContextType, RequireFields<SubscriptiondepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  _meta?: SubscriptionResolver<Maybe<ResolversTypes['_Meta_']>, "_meta", ParentType, ContextType, Partial<Subscription_metaArgs>>;
   delegateChange?: SubscriptionResolver<Maybe<ResolversTypes['DelegateChange']>, "delegateChange", ParentType, ContextType, RequireFields<SubscriptiondelegateChangeArgs, 'id' | 'subgraphError'>>;
   delegateChanges?: SubscriptionResolver<Array<ResolversTypes['DelegateChange']>, "delegateChanges", ParentType, ContextType, RequireFields<SubscriptiondelegateChangesArgs, 'skip' | 'first' | 'subgraphError'>>;
   delegateVotingPowerChange?: SubscriptionResolver<Maybe<ResolversTypes['DelegateVotingPowerChange']>, "delegateVotingPowerChange", ParentType, ContextType, RequireFields<SubscriptiondelegateVotingPowerChangeArgs, 'id' | 'subgraphError'>>;
@@ -8546,6 +8537,15 @@ export type SubscriptionResolvers<ContextType = MeshContext, ParentType extends 
   tokenDailySnapshots?: SubscriptionResolver<Array<ResolversTypes['TokenDailySnapshot']>, "tokenDailySnapshots", ParentType, ContextType, RequireFields<SubscriptiontokenDailySnapshotsArgs, 'skip' | 'first' | 'subgraphError'>>;
   voteDailySnapshot?: SubscriptionResolver<Maybe<ResolversTypes['VoteDailySnapshot']>, "voteDailySnapshot", ParentType, ContextType, RequireFields<SubscriptionvoteDailySnapshotArgs, 'id' | 'subgraphError'>>;
   voteDailySnapshots?: SubscriptionResolver<Array<ResolversTypes['VoteDailySnapshot']>, "voteDailySnapshots", ParentType, ContextType, RequireFields<SubscriptionvoteDailySnapshotsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  _meta?: SubscriptionResolver<Maybe<ResolversTypes['_Meta_']>, "_meta", ParentType, ContextType, Partial<Subscription_metaArgs>>;
+  aggregation?: SubscriptionResolver<Maybe<ResolversTypes['Aggregation']>, "aggregation", ParentType, ContextType, RequireFields<SubscriptionaggregationArgs, 'id' | 'subgraphError'>>;
+  aggregations?: SubscriptionResolver<Array<ResolversTypes['Aggregation']>, "aggregations", ParentType, ContextType, RequireFields<SubscriptionaggregationsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  depositor?: SubscriptionResolver<Maybe<ResolversTypes['Depositor']>, "depositor", ParentType, ContextType, RequireFields<SubscriptiondepositorArgs, 'id' | 'subgraphError'>>;
+  depositors?: SubscriptionResolver<Array<ResolversTypes['Depositor']>, "depositors", ParentType, ContextType, RequireFields<SubscriptiondepositorsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  dailyDeposit?: SubscriptionResolver<Maybe<ResolversTypes['DailyDeposit']>, "dailyDeposit", ParentType, ContextType, RequireFields<SubscriptiondailyDepositArgs, 'id' | 'subgraphError'>>;
+  dailyDeposits?: SubscriptionResolver<Array<ResolversTypes['DailyDeposit']>, "dailyDeposits", ParentType, ContextType, RequireFields<SubscriptiondailyDepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  deposit?: SubscriptionResolver<Maybe<ResolversTypes['Deposit']>, "deposit", ParentType, ContextType, RequireFields<SubscriptiondepositArgs, 'id' | 'subgraphError'>>;
+  deposits?: SubscriptionResolver<Array<ResolversTypes['Deposit']>, "deposits", ParentType, ContextType, RequireFields<SubscriptiondepositsArgs, 'skip' | 'first' | 'subgraphError'>>;
   account?: SubscriptionResolver<Maybe<ResolversTypes['Account']>, "account", ParentType, ContextType, RequireFields<SubscriptionaccountArgs, 'id' | 'subgraphError'>>;
   accounts?: SubscriptionResolver<Array<ResolversTypes['Account']>, "accounts", ParentType, ContextType, RequireFields<SubscriptionaccountsArgs, 'skip' | 'first' | 'subgraphError'>>;
   punk?: SubscriptionResolver<Maybe<ResolversTypes['Punk']>, "punk", ParentType, ContextType, RequireFields<SubscriptionpunkArgs, 'id' | 'subgraphError'>>;
@@ -8594,14 +8594,6 @@ export type SubscriptionResolvers<ContextType = MeshContext, ParentType extends 
   offers?: SubscriptionResolver<Array<ResolversTypes['Offer']>, "offers", ParentType, ContextType, RequireFields<SubscriptionoffersArgs, 'skip' | 'first' | 'subgraphError'>>;
 }>;
 
-export type AggregationResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Aggregation'] = ResolversParentTypes['Aggregation']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  totalDeposits?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  totalDepositors?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  totalAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
 export interface BigDecimalScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['BigDecimal'], any> {
   name: 'BigDecimal';
 }
@@ -8613,46 +8605,6 @@ export interface BigIntScalarConfig extends GraphQLScalarTypeConfig<ResolversTyp
 export interface BytesScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Bytes'], any> {
   name: 'Bytes';
 }
-
-export type DailyDepositResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['DailyDeposit'] = ResolversParentTypes['DailyDeposit']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  dailyAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  dailyDepositCount?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type DepositResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Deposit'] = ResolversParentTypes['Deposit']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  dayID?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  depositor?: Resolver<Maybe<ResolversTypes['Depositor']>, ParentType, ContextType>;
-  pubkey?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
-  withdrawal_credentials?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
-  amount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
-  timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type DepositorResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Depositor'] = ResolversParentTypes['Depositor']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  totalAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  depositCount?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
-  deposits?: Resolver<Maybe<Array<ResolversTypes['Deposit']>>, ParentType, ContextType, RequireFields<DepositordepositsArgs, 'skip' | 'first'>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type _Block_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Block_'] = ResolversParentTypes['_Block_']> = ResolversObject<{
-  hash?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
-  number?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  timestamp?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type _Meta_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Meta_'] = ResolversParentTypes['_Meta_']> = ResolversObject<{
-  block?: Resolver<ResolversTypes['_Block_'], ParentType, ContextType>;
-  deployment?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  hasIndexingErrors?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
 
 export type DelegateResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Delegate'] = ResolversParentTypes['Delegate']> = ResolversObject<{
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -8807,6 +8759,54 @@ export type VoteDailySnapshotResolvers<ContextType = MeshContext, ParentType ext
   totalWeightedVotes?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
   blockNumber?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
   timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type _Block_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Block_'] = ResolversParentTypes['_Block_']> = ResolversObject<{
+  hash?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
+  number?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  timestamp?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type _Meta_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Meta_'] = ResolversParentTypes['_Meta_']> = ResolversObject<{
+  block?: Resolver<ResolversTypes['_Block_'], ParentType, ContextType>;
+  deployment?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hasIndexingErrors?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type AggregationResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Aggregation'] = ResolversParentTypes['Aggregation']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  totalDeposits?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  totalDepositors?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  totalAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type DailyDepositResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['DailyDeposit'] = ResolversParentTypes['DailyDeposit']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  dailyAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  dailyDepositCount?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type DepositResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Deposit'] = ResolversParentTypes['Deposit']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  dayID?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  depositor?: Resolver<Maybe<ResolversTypes['Depositor']>, ParentType, ContextType>;
+  pubkey?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  withdrawal_credentials?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  amount?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  timestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type DepositorResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Depositor'] = ResolversParentTypes['Depositor']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  totalAmountDeposited?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  depositCount?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  deposits?: Resolver<Maybe<Array<ResolversTypes['Deposit']>>, ParentType, ContextType, RequireFields<DepositordepositsArgs, 'skip' | 'first'>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -9142,15 +9142,9 @@ export type WrapResolvers<ContextType = MeshContext, ParentType extends Resolver
 export type Resolvers<ContextType = MeshContext> = ResolversObject<{
   Query?: QueryResolvers<ContextType>;
   Subscription?: SubscriptionResolvers<ContextType>;
-  Aggregation?: AggregationResolvers<ContextType>;
   BigDecimal?: GraphQLScalarType;
   BigInt?: GraphQLScalarType;
   Bytes?: GraphQLScalarType;
-  DailyDeposit?: DailyDepositResolvers<ContextType>;
-  Deposit?: DepositResolvers<ContextType>;
-  Depositor?: DepositorResolvers<ContextType>;
-  _Block_?: _Block_Resolvers<ContextType>;
-  _Meta_?: _Meta_Resolvers<ContextType>;
   Delegate?: DelegateResolvers<ContextType>;
   DelegateChange?: DelegateChangeResolvers<ContextType>;
   DelegateVotingPowerChange?: DelegateVotingPowerChangeResolvers<ContextType>;
@@ -9161,6 +9155,12 @@ export type Resolvers<ContextType = MeshContext> = ResolversObject<{
   TokenHolder?: TokenHolderResolvers<ContextType>;
   Vote?: VoteResolvers<ContextType>;
   VoteDailySnapshot?: VoteDailySnapshotResolvers<ContextType>;
+  _Block_?: _Block_Resolvers<ContextType>;
+  _Meta_?: _Meta_Resolvers<ContextType>;
+  Aggregation?: AggregationResolvers<ContextType>;
+  DailyDeposit?: DailyDepositResolvers<ContextType>;
+  Deposit?: DepositResolvers<ContextType>;
+  Depositor?: DepositorResolvers<ContextType>;
   Account?: AccountResolvers<ContextType>;
   Ask?: AskResolvers<ContextType>;
   AskCreated?: AskCreatedResolvers<ContextType>;
@@ -9192,7 +9192,7 @@ export type DirectiveResolvers<ContextType = MeshContext> = ResolversObject<{
   derivedFrom?: derivedFromDirectiveResolver<any, any, ContextType>;
 }>;
 
-export type MeshContext = BeaconDepositorsTypes.Context & EnsGovernanceTypes.Context & CryptopunksTypes.Context & BaseMeshContext;
+export type MeshContext = EnsGovernanceTypes.Context & BeaconDepositorsTypes.Context & CryptopunksTypes.Context & BaseMeshContext;
 
 
 const baseDir = pathModule.join(typeof __dirname === 'string' ? __dirname : '/', '..');
@@ -9200,11 +9200,11 @@ const baseDir = pathModule.join(typeof __dirname === 'string' ? __dirname : '/',
 const importFn: ImportFn = <T>(moduleId: string) => {
   const relativeModuleId = (pathModule.isAbsolute(moduleId) ? pathModule.relative(baseDir, moduleId) : moduleId).split('\\').join('/').replace(baseDir + '/', '');
   switch(relativeModuleId) {
-    case ".graphclient/sources/beacon-depositors/introspectionSchema":
-      return import("./sources/beacon-depositors/introspectionSchema") as T;
-    
     case ".graphclient/sources/ens-governance/introspectionSchema":
       return import("./sources/ens-governance/introspectionSchema") as T;
+    
+    case ".graphclient/sources/beacon-depositors/introspectionSchema":
+      return import("./sources/beacon-depositors/introspectionSchema") as T;
     
     case ".graphclient/sources/cryptopunks/introspectionSchema":
       return import("./sources/cryptopunks/introspectionSchema") as T;
@@ -9374,6 +9374,7 @@ export type BeaconDepositorsQuery = { depositors: Array<Pick<Depositor, 'id'>> }
 export type VotersPerProposalQueryVariables = Exact<{
   id: Scalars['ID'];
   choice?: InputMaybe<VoteChoice>;
+  skip?: InputMaybe<Scalars['Int']>;
 }>;
 
 
@@ -9398,7 +9399,7 @@ export const BeaconDepositorsDocument = gql`
 }
     ` as unknown as DocumentNode<BeaconDepositorsQuery, BeaconDepositorsQueryVariables>;
 export const VotersPerProposalDocument = gql`
-    query VotersPerProposal($id: ID!, $choice: VoteChoice) {
+    query VotersPerProposal($id: ID!, $choice: VoteChoice, $skip: Int) {
   proposal(id: $id) {
     state
     votes(where: {choice: $choice}) {

--- a/apis/query/src/lib/graph/.graphclient/schema.graphql
+++ b/apis/query/src/lib/graph/.graphclient/schema.graphql
@@ -13,112 +13,6 @@ directive @subgraphId(id: String!) on OBJECT
 directive @derivedFrom(field: String!) on FIELD_DEFINITION
 
 type Query {
-  aggregation(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Aggregation
-  aggregations(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Aggregation_orderBy
-    orderDirection: OrderDirection
-    where: Aggregation_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Aggregation!]!
-  depositor(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Depositor
-  depositors(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Depositor_orderBy
-    orderDirection: OrderDirection
-    where: Depositor_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Depositor!]!
-  dailyDeposit(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): DailyDeposit
-  dailyDeposits(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: DailyDeposit_orderBy
-    orderDirection: OrderDirection
-    where: DailyDeposit_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [DailyDeposit!]!
-  deposit(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Deposit
-  deposits(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Deposit_orderBy
-    orderDirection: OrderDirection
-    where: Deposit_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Deposit!]!
-  """Access to subgraph metadata"""
-  _meta(block: Block_height): _Meta_
   delegateChange(
     id: ID!
     """
@@ -379,6 +273,112 @@ type Query {
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [VoteDailySnapshot!]!
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+  aggregation(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Aggregation
+  aggregations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Aggregation_orderBy
+    orderDirection: OrderDirection
+    where: Aggregation_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Aggregation!]!
+  depositor(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Depositor
+  depositors(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Depositor_orderBy
+    orderDirection: OrderDirection
+    where: Depositor_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Depositor!]!
+  dailyDeposit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): DailyDeposit
+  dailyDeposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: DailyDeposit_orderBy
+    orderDirection: OrderDirection
+    where: DailyDeposit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [DailyDeposit!]!
+  deposit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Deposit
+  deposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Deposit_orderBy
+    orderDirection: OrderDirection
+    where: Deposit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Deposit!]!
   account(
     id: ID!
     """
@@ -980,112 +980,6 @@ type Query {
 }
 
 type Subscription {
-  aggregation(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Aggregation
-  aggregations(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Aggregation_orderBy
-    orderDirection: OrderDirection
-    where: Aggregation_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Aggregation!]!
-  depositor(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Depositor
-  depositors(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Depositor_orderBy
-    orderDirection: OrderDirection
-    where: Depositor_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Depositor!]!
-  dailyDeposit(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): DailyDeposit
-  dailyDeposits(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: DailyDeposit_orderBy
-    orderDirection: OrderDirection
-    where: DailyDeposit_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [DailyDeposit!]!
-  deposit(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Deposit
-  deposits(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Deposit_orderBy
-    orderDirection: OrderDirection
-    where: Deposit_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Deposit!]!
-  """Access to subgraph metadata"""
-  _meta(block: Block_height): _Meta_
   delegateChange(
     id: ID!
     """
@@ -1346,6 +1240,112 @@ type Subscription {
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [VoteDailySnapshot!]!
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
+  aggregation(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Aggregation
+  aggregations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Aggregation_orderBy
+    orderDirection: OrderDirection
+    where: Aggregation_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Aggregation!]!
+  depositor(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Depositor
+  depositors(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Depositor_orderBy
+    orderDirection: OrderDirection
+    where: Depositor_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Depositor!]!
+  dailyDeposit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): DailyDeposit
+  dailyDeposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: DailyDeposit_orderBy
+    orderDirection: OrderDirection
+    where: DailyDeposit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [DailyDeposit!]!
+  deposit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Deposit
+  deposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Deposit_orderBy
+    orderDirection: OrderDirection
+    where: Deposit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Deposit!]!
   account(
     id: ID!
     """
@@ -1946,59 +1946,6 @@ type Subscription {
   ): [Offer!]!
 }
 
-type Aggregation {
-  id: ID!
-  totalDeposits: BigInt
-  totalDepositors: BigInt
-  totalAmountDeposited: BigInt
-}
-
-input Aggregation_filter {
-  id: ID
-  id_not: ID
-  id_gt: ID
-  id_lt: ID
-  id_gte: ID
-  id_lte: ID
-  id_in: [ID!]
-  id_not_in: [ID!]
-  totalDeposits: BigInt
-  totalDeposits_not: BigInt
-  totalDeposits_gt: BigInt
-  totalDeposits_lt: BigInt
-  totalDeposits_gte: BigInt
-  totalDeposits_lte: BigInt
-  totalDeposits_in: [BigInt!]
-  totalDeposits_not_in: [BigInt!]
-  totalDepositors: BigInt
-  totalDepositors_not: BigInt
-  totalDepositors_gt: BigInt
-  totalDepositors_lt: BigInt
-  totalDepositors_gte: BigInt
-  totalDepositors_lte: BigInt
-  totalDepositors_in: [BigInt!]
-  totalDepositors_not_in: [BigInt!]
-  totalAmountDeposited: BigInt
-  totalAmountDeposited_not: BigInt
-  totalAmountDeposited_gt: BigInt
-  totalAmountDeposited_lt: BigInt
-  totalAmountDeposited_gte: BigInt
-  totalAmountDeposited_lte: BigInt
-  totalAmountDeposited_in: [BigInt!]
-  totalAmountDeposited_not_in: [BigInt!]
-  """Filter for the block changed event."""
-  _change_block: BlockChangedFilter
-  and: [Aggregation_filter]
-  or: [Aggregation_filter]
-}
-
-enum Aggregation_orderBy {
-  id
-  totalDeposits
-  totalDepositors
-  totalAmountDeposited
-}
-
 scalar BigDecimal
 
 scalar BigInt
@@ -2014,250 +1961,6 @@ input Block_height {
 }
 
 scalar Bytes
-
-type DailyDeposit {
-  id: ID!
-  dailyAmountDeposited: BigInt
-  dailyDepositCount: BigInt
-}
-
-input DailyDeposit_filter {
-  id: ID
-  id_not: ID
-  id_gt: ID
-  id_lt: ID
-  id_gte: ID
-  id_lte: ID
-  id_in: [ID!]
-  id_not_in: [ID!]
-  dailyAmountDeposited: BigInt
-  dailyAmountDeposited_not: BigInt
-  dailyAmountDeposited_gt: BigInt
-  dailyAmountDeposited_lt: BigInt
-  dailyAmountDeposited_gte: BigInt
-  dailyAmountDeposited_lte: BigInt
-  dailyAmountDeposited_in: [BigInt!]
-  dailyAmountDeposited_not_in: [BigInt!]
-  dailyDepositCount: BigInt
-  dailyDepositCount_not: BigInt
-  dailyDepositCount_gt: BigInt
-  dailyDepositCount_lt: BigInt
-  dailyDepositCount_gte: BigInt
-  dailyDepositCount_lte: BigInt
-  dailyDepositCount_in: [BigInt!]
-  dailyDepositCount_not_in: [BigInt!]
-  """Filter for the block changed event."""
-  _change_block: BlockChangedFilter
-  and: [DailyDeposit_filter]
-  or: [DailyDeposit_filter]
-}
-
-enum DailyDeposit_orderBy {
-  id
-  dailyAmountDeposited
-  dailyDepositCount
-}
-
-type Deposit {
-  id: ID!
-  dayID: String!
-  depositor: Depositor
-  pubkey: Bytes!
-  withdrawal_credentials: Bytes!
-  amount: BigInt!
-  timestamp: BigInt!
-}
-
-input Deposit_filter {
-  id: ID
-  id_not: ID
-  id_gt: ID
-  id_lt: ID
-  id_gte: ID
-  id_lte: ID
-  id_in: [ID!]
-  id_not_in: [ID!]
-  dayID: String
-  dayID_not: String
-  dayID_gt: String
-  dayID_lt: String
-  dayID_gte: String
-  dayID_lte: String
-  dayID_in: [String!]
-  dayID_not_in: [String!]
-  dayID_contains: String
-  dayID_contains_nocase: String
-  dayID_not_contains: String
-  dayID_not_contains_nocase: String
-  dayID_starts_with: String
-  dayID_starts_with_nocase: String
-  dayID_not_starts_with: String
-  dayID_not_starts_with_nocase: String
-  dayID_ends_with: String
-  dayID_ends_with_nocase: String
-  dayID_not_ends_with: String
-  dayID_not_ends_with_nocase: String
-  depositor: String
-  depositor_not: String
-  depositor_gt: String
-  depositor_lt: String
-  depositor_gte: String
-  depositor_lte: String
-  depositor_in: [String!]
-  depositor_not_in: [String!]
-  depositor_contains: String
-  depositor_contains_nocase: String
-  depositor_not_contains: String
-  depositor_not_contains_nocase: String
-  depositor_starts_with: String
-  depositor_starts_with_nocase: String
-  depositor_not_starts_with: String
-  depositor_not_starts_with_nocase: String
-  depositor_ends_with: String
-  depositor_ends_with_nocase: String
-  depositor_not_ends_with: String
-  depositor_not_ends_with_nocase: String
-  depositor_: Depositor_filter
-  pubkey: Bytes
-  pubkey_not: Bytes
-  pubkey_gt: Bytes
-  pubkey_lt: Bytes
-  pubkey_gte: Bytes
-  pubkey_lte: Bytes
-  pubkey_in: [Bytes!]
-  pubkey_not_in: [Bytes!]
-  pubkey_contains: Bytes
-  pubkey_not_contains: Bytes
-  withdrawal_credentials: Bytes
-  withdrawal_credentials_not: Bytes
-  withdrawal_credentials_gt: Bytes
-  withdrawal_credentials_lt: Bytes
-  withdrawal_credentials_gte: Bytes
-  withdrawal_credentials_lte: Bytes
-  withdrawal_credentials_in: [Bytes!]
-  withdrawal_credentials_not_in: [Bytes!]
-  withdrawal_credentials_contains: Bytes
-  withdrawal_credentials_not_contains: Bytes
-  amount: BigInt
-  amount_not: BigInt
-  amount_gt: BigInt
-  amount_lt: BigInt
-  amount_gte: BigInt
-  amount_lte: BigInt
-  amount_in: [BigInt!]
-  amount_not_in: [BigInt!]
-  timestamp: BigInt
-  timestamp_not: BigInt
-  timestamp_gt: BigInt
-  timestamp_lt: BigInt
-  timestamp_gte: BigInt
-  timestamp_lte: BigInt
-  timestamp_in: [BigInt!]
-  timestamp_not_in: [BigInt!]
-  """Filter for the block changed event."""
-  _change_block: BlockChangedFilter
-  and: [Deposit_filter]
-  or: [Deposit_filter]
-}
-
-enum Deposit_orderBy {
-  id
-  dayID
-  depositor
-  depositor__id
-  depositor__totalAmountDeposited
-  depositor__depositCount
-  pubkey
-  withdrawal_credentials
-  amount
-  timestamp
-}
-
-type Depositor {
-  id: ID!
-  totalAmountDeposited: BigInt
-  depositCount: BigInt
-  deposits(skip: Int = 0, first: Int = 100, orderBy: Deposit_orderBy, orderDirection: OrderDirection, where: Deposit_filter): [Deposit!]
-}
-
-input Depositor_filter {
-  id: ID
-  id_not: ID
-  id_gt: ID
-  id_lt: ID
-  id_gte: ID
-  id_lte: ID
-  id_in: [ID!]
-  id_not_in: [ID!]
-  totalAmountDeposited: BigInt
-  totalAmountDeposited_not: BigInt
-  totalAmountDeposited_gt: BigInt
-  totalAmountDeposited_lt: BigInt
-  totalAmountDeposited_gte: BigInt
-  totalAmountDeposited_lte: BigInt
-  totalAmountDeposited_in: [BigInt!]
-  totalAmountDeposited_not_in: [BigInt!]
-  depositCount: BigInt
-  depositCount_not: BigInt
-  depositCount_gt: BigInt
-  depositCount_lt: BigInt
-  depositCount_gte: BigInt
-  depositCount_lte: BigInt
-  depositCount_in: [BigInt!]
-  depositCount_not_in: [BigInt!]
-  deposits_: Deposit_filter
-  """Filter for the block changed event."""
-  _change_block: BlockChangedFilter
-  and: [Depositor_filter]
-  or: [Depositor_filter]
-}
-
-enum Depositor_orderBy {
-  id
-  totalAmountDeposited
-  depositCount
-  deposits
-}
-
-"""Defines the order direction, either ascending or descending"""
-enum OrderDirection {
-  asc
-  desc
-}
-
-type _Block_ {
-  """The hash of the block"""
-  hash: Bytes
-  """The block number"""
-  number: Int!
-  """Integer representation of the timestamp stored in blocks for the chain"""
-  timestamp: Int
-}
-
-"""The type for the top-level _meta field"""
-type _Meta_ {
-  """
-  Information about a specific subgraph block. The hash of the block
-  will be null if the _meta field has a block constraint that asks for
-  a block number. It will be filled if the _meta field has no block constraint
-  and therefore asks for the latest  block
-  
-  """
-  block: _Block_!
-  """The deployment ID"""
-  deployment: String!
-  """If `true`, the subgraph encountered indexing errors at some past block"""
-  hasIndexingErrors: Boolean!
-}
-
-enum _SubgraphErrorPolicy_ {
-  """Data will be returned even if the subgraph has indexing errors"""
-  allow
-  """
-  If the subgraph has indexing errors, data will be omitted. The default.
-  """
-  deny
-}
 
 type Delegate {
   """
@@ -3052,6 +2755,12 @@ enum Governance_orderBy {
   proposalsQueued
   proposalsExecuted
   proposalsCanceled
+}
+
+"""Defines the order direction, either ascending or descending"""
+enum OrderDirection {
+  asc
+  desc
 }
 
 type Proposal {
@@ -4006,6 +3715,297 @@ enum Vote_orderBy {
   block
   blockTime
   txnHash
+}
+
+type _Block_ {
+  """The hash of the block"""
+  hash: Bytes
+  """The block number"""
+  number: Int!
+  """Integer representation of the timestamp stored in blocks for the chain"""
+  timestamp: Int
+}
+
+"""The type for the top-level _meta field"""
+type _Meta_ {
+  """
+  Information about a specific subgraph block. The hash of the block
+  will be null if the _meta field has a block constraint that asks for
+  a block number. It will be filled if the _meta field has no block constraint
+  and therefore asks for the latest  block
+  
+  """
+  block: _Block_!
+  """The deployment ID"""
+  deployment: String!
+  """If `true`, the subgraph encountered indexing errors at some past block"""
+  hasIndexingErrors: Boolean!
+}
+
+enum _SubgraphErrorPolicy_ {
+  """Data will be returned even if the subgraph has indexing errors"""
+  allow
+  """
+  If the subgraph has indexing errors, data will be omitted. The default.
+  """
+  deny
+}
+
+type Aggregation {
+  id: ID!
+  totalDeposits: BigInt
+  totalDepositors: BigInt
+  totalAmountDeposited: BigInt
+}
+
+input Aggregation_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  totalDeposits: BigInt
+  totalDeposits_not: BigInt
+  totalDeposits_gt: BigInt
+  totalDeposits_lt: BigInt
+  totalDeposits_gte: BigInt
+  totalDeposits_lte: BigInt
+  totalDeposits_in: [BigInt!]
+  totalDeposits_not_in: [BigInt!]
+  totalDepositors: BigInt
+  totalDepositors_not: BigInt
+  totalDepositors_gt: BigInt
+  totalDepositors_lt: BigInt
+  totalDepositors_gte: BigInt
+  totalDepositors_lte: BigInt
+  totalDepositors_in: [BigInt!]
+  totalDepositors_not_in: [BigInt!]
+  totalAmountDeposited: BigInt
+  totalAmountDeposited_not: BigInt
+  totalAmountDeposited_gt: BigInt
+  totalAmountDeposited_lt: BigInt
+  totalAmountDeposited_gte: BigInt
+  totalAmountDeposited_lte: BigInt
+  totalAmountDeposited_in: [BigInt!]
+  totalAmountDeposited_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Aggregation_filter]
+  or: [Aggregation_filter]
+}
+
+enum Aggregation_orderBy {
+  id
+  totalDeposits
+  totalDepositors
+  totalAmountDeposited
+}
+
+type DailyDeposit {
+  id: ID!
+  dailyAmountDeposited: BigInt
+  dailyDepositCount: BigInt
+}
+
+input DailyDeposit_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  dailyAmountDeposited: BigInt
+  dailyAmountDeposited_not: BigInt
+  dailyAmountDeposited_gt: BigInt
+  dailyAmountDeposited_lt: BigInt
+  dailyAmountDeposited_gte: BigInt
+  dailyAmountDeposited_lte: BigInt
+  dailyAmountDeposited_in: [BigInt!]
+  dailyAmountDeposited_not_in: [BigInt!]
+  dailyDepositCount: BigInt
+  dailyDepositCount_not: BigInt
+  dailyDepositCount_gt: BigInt
+  dailyDepositCount_lt: BigInt
+  dailyDepositCount_gte: BigInt
+  dailyDepositCount_lte: BigInt
+  dailyDepositCount_in: [BigInt!]
+  dailyDepositCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [DailyDeposit_filter]
+  or: [DailyDeposit_filter]
+}
+
+enum DailyDeposit_orderBy {
+  id
+  dailyAmountDeposited
+  dailyDepositCount
+}
+
+type Deposit {
+  id: ID!
+  dayID: String!
+  depositor: Depositor
+  pubkey: Bytes!
+  withdrawal_credentials: Bytes!
+  amount: BigInt!
+  timestamp: BigInt!
+}
+
+input Deposit_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  dayID: String
+  dayID_not: String
+  dayID_gt: String
+  dayID_lt: String
+  dayID_gte: String
+  dayID_lte: String
+  dayID_in: [String!]
+  dayID_not_in: [String!]
+  dayID_contains: String
+  dayID_contains_nocase: String
+  dayID_not_contains: String
+  dayID_not_contains_nocase: String
+  dayID_starts_with: String
+  dayID_starts_with_nocase: String
+  dayID_not_starts_with: String
+  dayID_not_starts_with_nocase: String
+  dayID_ends_with: String
+  dayID_ends_with_nocase: String
+  dayID_not_ends_with: String
+  dayID_not_ends_with_nocase: String
+  depositor: String
+  depositor_not: String
+  depositor_gt: String
+  depositor_lt: String
+  depositor_gte: String
+  depositor_lte: String
+  depositor_in: [String!]
+  depositor_not_in: [String!]
+  depositor_contains: String
+  depositor_contains_nocase: String
+  depositor_not_contains: String
+  depositor_not_contains_nocase: String
+  depositor_starts_with: String
+  depositor_starts_with_nocase: String
+  depositor_not_starts_with: String
+  depositor_not_starts_with_nocase: String
+  depositor_ends_with: String
+  depositor_ends_with_nocase: String
+  depositor_not_ends_with: String
+  depositor_not_ends_with_nocase: String
+  depositor_: Depositor_filter
+  pubkey: Bytes
+  pubkey_not: Bytes
+  pubkey_gt: Bytes
+  pubkey_lt: Bytes
+  pubkey_gte: Bytes
+  pubkey_lte: Bytes
+  pubkey_in: [Bytes!]
+  pubkey_not_in: [Bytes!]
+  pubkey_contains: Bytes
+  pubkey_not_contains: Bytes
+  withdrawal_credentials: Bytes
+  withdrawal_credentials_not: Bytes
+  withdrawal_credentials_gt: Bytes
+  withdrawal_credentials_lt: Bytes
+  withdrawal_credentials_gte: Bytes
+  withdrawal_credentials_lte: Bytes
+  withdrawal_credentials_in: [Bytes!]
+  withdrawal_credentials_not_in: [Bytes!]
+  withdrawal_credentials_contains: Bytes
+  withdrawal_credentials_not_contains: Bytes
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Deposit_filter]
+  or: [Deposit_filter]
+}
+
+enum Deposit_orderBy {
+  id
+  dayID
+  depositor
+  depositor__id
+  depositor__totalAmountDeposited
+  depositor__depositCount
+  pubkey
+  withdrawal_credentials
+  amount
+  timestamp
+}
+
+type Depositor {
+  id: ID!
+  totalAmountDeposited: BigInt
+  depositCount: BigInt
+  deposits(skip: Int = 0, first: Int = 100, orderBy: Deposit_orderBy, orderDirection: OrderDirection, where: Deposit_filter): [Deposit!]
+}
+
+input Depositor_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  totalAmountDeposited: BigInt
+  totalAmountDeposited_not: BigInt
+  totalAmountDeposited_gt: BigInt
+  totalAmountDeposited_lt: BigInt
+  totalAmountDeposited_gte: BigInt
+  totalAmountDeposited_lte: BigInt
+  totalAmountDeposited_in: [BigInt!]
+  totalAmountDeposited_not_in: [BigInt!]
+  depositCount: BigInt
+  depositCount_not: BigInt
+  depositCount_gt: BigInt
+  depositCount_lt: BigInt
+  depositCount_gte: BigInt
+  depositCount_lte: BigInt
+  depositCount_in: [BigInt!]
+  depositCount_not_in: [BigInt!]
+  deposits_: Deposit_filter
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Depositor_filter]
+  or: [Depositor_filter]
+}
+
+enum Depositor_orderBy {
+  id
+  totalAmountDeposited
+  depositCount
+  deposits
 }
 
 type Account {

--- a/apis/query/src/lib/graph/.graphclient/schema.graphql
+++ b/apis/query/src/lib/graph/.graphclient/schema.graphql
@@ -3,6 +3,15 @@ schema {
   subscription: Subscription
 }
 
+"Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive."
+directive @entity on OBJECT
+
+"Defined a Subgraph ID for an object type"
+directive @subgraphId(id: String!) on OBJECT
+
+"creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API."
+directive @derivedFrom(field: String!) on FIELD_DEFINITION
+
 type Query {
   delegateChange(
     id: ID!
@@ -3784,6 +3793,8 @@ input Aggregation_filter {
   totalAmountDeposited_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Aggregation_filter]
+  or: [Aggregation_filter]
 }
 
 enum Aggregation_orderBy {
@@ -3826,6 +3837,8 @@ input DailyDeposit_filter {
   dailyDepositCount_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [DailyDeposit_filter]
+  or: [DailyDeposit_filter]
 }
 
 enum DailyDeposit_orderBy {
@@ -3896,12 +3909,20 @@ input Deposit_filter {
   depositor_: Depositor_filter
   pubkey: Bytes
   pubkey_not: Bytes
+  pubkey_gt: Bytes
+  pubkey_lt: Bytes
+  pubkey_gte: Bytes
+  pubkey_lte: Bytes
   pubkey_in: [Bytes!]
   pubkey_not_in: [Bytes!]
   pubkey_contains: Bytes
   pubkey_not_contains: Bytes
   withdrawal_credentials: Bytes
   withdrawal_credentials_not: Bytes
+  withdrawal_credentials_gt: Bytes
+  withdrawal_credentials_lt: Bytes
+  withdrawal_credentials_gte: Bytes
+  withdrawal_credentials_lte: Bytes
   withdrawal_credentials_in: [Bytes!]
   withdrawal_credentials_not_in: [Bytes!]
   withdrawal_credentials_contains: Bytes
@@ -3924,12 +3945,17 @@ input Deposit_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Deposit_filter]
+  or: [Deposit_filter]
 }
 
 enum Deposit_orderBy {
   id
   dayID
   depositor
+  depositor__id
+  depositor__totalAmountDeposited
+  depositor__depositCount
   pubkey
   withdrawal_credentials
   amount
@@ -3971,6 +3997,8 @@ input Depositor_filter {
   deposits_: Deposit_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Depositor_filter]
+  or: [Depositor_filter]
 }
 
 enum Depositor_orderBy {
@@ -4022,12 +4050,17 @@ type Account {
 input Account_filter {
   id: Bytes
   id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
   id_in: [Bytes!]
   id_not_in: [Bytes!]
   id_contains: Bytes
   id_not_contains: Bytes
   punksOwned_: Punk_filter
   bought_: Sale_filter
+  nftsOwned_: NFT_filter
   assigned_: Assign_filter
   sent_: Transfer_filter
   received_: Transfer_filter
@@ -4119,6 +4152,8 @@ input Account_filter {
   accountUrl_not_ends_with_nocase: String
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Account_filter]
+  or: [Account_filter]
 }
 
 enum Account_orderBy {
@@ -4301,6 +4336,7 @@ input AskCreated_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -4323,12 +4359,20 @@ input AskCreated_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -4343,16 +4387,53 @@ input AskCreated_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [AskCreated_filter]
+  or: [AskCreated_filter]
 }
 
 enum AskCreated_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   ask
+  ask__id
+  ask__open
+  ask__amount
+  ask__offerType
   amount
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -4503,6 +4584,7 @@ input AskRemoved_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -4525,12 +4607,20 @@ input AskRemoved_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -4545,16 +4635,53 @@ input AskRemoved_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [AskRemoved_filter]
+  or: [AskRemoved_filter]
 }
 
 enum AskRemoved_orderBy {
   id
   ask
+  ask__id
+  ask__open
+  ask__amount
+  ask__offerType
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -4625,6 +4752,7 @@ input Ask_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   created: String
   created_not: String
   created_gt: String
@@ -4645,6 +4773,7 @@ input Ask_filter {
   created_ends_with_nocase: String
   created_not_ends_with: String
   created_not_ends_with_nocase: String
+  created_: Event_filter
   removed: String
   removed_not: String
   removed_gt: String
@@ -4665,22 +4794,55 @@ input Ask_filter {
   removed_ends_with_nocase: String
   removed_not_ends_with: String
   removed_not_ends_with_nocase: String
+  removed_: Event_filter
   offerType: OfferType
   offerType_not: OfferType
   offerType_in: [OfferType!]
   offerType_not_in: [OfferType!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Ask_filter]
+  or: [Ask_filter]
 }
 
 enum Ask_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   open
   amount
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   created
+  created__id
+  created__amount
+  created__type
+  created__logNumber
+  created__blockNumber
+  created__blockHash
+  created__txHash
+  created__timestamp
   removed
+  removed__id
+  removed__amount
+  removed__type
+  removed__logNumber
+  removed__blockNumber
+  removed__blockHash
+  removed__txHash
+  removed__timestamp
   offerType
 }
 
@@ -4753,6 +4915,7 @@ input Assign_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   to: String
   to_not: String
   to_gt: String
@@ -4825,12 +4988,20 @@ input Assign_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -4845,15 +5016,48 @@ input Assign_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Assign_filter]
+  or: [Assign_filter]
 }
 
 enum Assign_orderBy {
   id
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   type
   logNumber
   blockNumber
@@ -5021,6 +5225,7 @@ input BidCreated_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -5043,12 +5248,20 @@ input BidCreated_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -5063,16 +5276,53 @@ input BidCreated_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [BidCreated_filter]
+  or: [BidCreated_filter]
 }
 
 enum BidCreated_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   bid
+  bid__id
+  bid__open
+  bid__amount
+  bid__offerType
   amount
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -5223,6 +5473,7 @@ input BidRemoved_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -5245,12 +5496,20 @@ input BidRemoved_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -5265,16 +5524,53 @@ input BidRemoved_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [BidRemoved_filter]
+  or: [BidRemoved_filter]
 }
 
 enum BidRemoved_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   bid
+  bid__id
+  bid__open
+  bid__amount
+  bid__offerType
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -5345,6 +5641,7 @@ input Bid_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   created: String
   created_not: String
   created_gt: String
@@ -5365,6 +5662,7 @@ input Bid_filter {
   created_ends_with_nocase: String
   created_not_ends_with: String
   created_not_ends_with_nocase: String
+  created_: Event_filter
   removed: String
   removed_not: String
   removed_gt: String
@@ -5385,22 +5683,55 @@ input Bid_filter {
   removed_ends_with_nocase: String
   removed_not_ends_with: String
   removed_not_ends_with_nocase: String
+  removed_: Event_filter
   offerType: OfferType
   offerType_not: OfferType
   offerType_in: [OfferType!]
   offerType_not_in: [OfferType!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Bid_filter]
+  or: [Bid_filter]
 }
 
 enum Bid_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   open
   amount
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   created
+  created__id
+  created__amount
+  created__type
+  created__logNumber
+  created__blockNumber
+  created__blockHash
+  created__txHash
+  created__timestamp
   removed
+  removed__id
+  removed__amount
+  removed__type
+  removed__logNumber
+  removed__blockNumber
+  removed__blockHash
+  removed__txHash
+  removed__timestamp
   offerType
 }
 
@@ -5554,12 +5885,20 @@ input CToken_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -5574,12 +5913,34 @@ input CToken_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [CToken_filter]
+  or: [CToken_filter]
 }
 
 enum CToken_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   owner
   amount
   punkId
@@ -5702,6 +6063,8 @@ input Contract_filter {
   imageHash_not_ends_with_nocase: String
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Contract_filter]
+  or: [Contract_filter]
 }
 
 enum Contract_orderBy {
@@ -5738,6 +6101,8 @@ input EpnsNotificationCounter_filter {
   totalCount_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [EpnsNotificationCounter_filter]
+  or: [EpnsNotificationCounter_filter]
 }
 
 enum EpnsNotificationCounter_orderBy {
@@ -5811,6 +6176,8 @@ input EpnsPushNotification_filter {
   notification_not_ends_with_nocase: String
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [EpnsPushNotification_filter]
+  or: [EpnsPushNotification_filter]
 }
 
 enum EpnsPushNotification_orderBy {
@@ -5950,6 +6317,7 @@ input Event_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   type: EventType
   type_not: EventType
   type_in: [EventType!]
@@ -5972,12 +6340,20 @@ input Event_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -5992,15 +6368,48 @@ input Event_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Event_filter]
+  or: [Event_filter]
 }
 
 enum Event_orderBy {
   id
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   type
   logNumber
   blockNumber
@@ -6153,6 +6562,8 @@ input MetaData_filter {
   traits_: Trait_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [MetaData_filter]
+  or: [MetaData_filter]
 }
 
 enum MetaData_orderBy {
@@ -6163,6 +6574,13 @@ enum MetaData_orderBy {
   svg
   contractURI
   punk
+  punk__id
+  punk__tokenId
+  punk__wrapped
+  punk__numberOfTransfers
+  punk__numberOfSales
+  punk__totalAmountSpentOnPunk
+  punk__averageSalePrice
   traits
 }
 
@@ -6259,6 +6677,7 @@ input NFT_filter {
   owner_not_ends_with: String
   owner_not_ends_with_nocase: String
   owner_: Account_filter
+  events_: Event_filter
   currentAsk: String
   currentAsk_not: String
   currentAsk_gt: String
@@ -6303,18 +6722,45 @@ input NFT_filter {
   currentBid_: Bid_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [NFT_filter]
+  or: [NFT_filter]
 }
 
 enum NFT_orderBy {
   id
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   numberOfTransfers
   numberOfSales
   tokenId
   owner
+  owner__id
+  owner__numberOfPunksOwned
+  owner__numberOfPunksAssigned
+  owner__numberOfTransfers
+  owner__numberOfSales
+  owner__numberOfPurchases
+  owner__totalSpent
+  owner__totalEarned
+  owner__averageAmountSpent
+  owner__accountUrl
   events
   currentAsk
+  currentAsk__id
+  currentAsk__open
+  currentAsk__amount
+  currentAsk__offerType
   currentBid
+  currentBid__id
+  currentBid__open
+  currentBid__amount
+  currentBid__offerType
 }
 
 interface Offer {
@@ -6401,6 +6847,7 @@ input Offer_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   created: String
   created_not: String
   created_gt: String
@@ -6421,6 +6868,7 @@ input Offer_filter {
   created_ends_with_nocase: String
   created_not_ends_with: String
   created_not_ends_with_nocase: String
+  created_: Event_filter
   removed: String
   removed_not: String
   removed_gt: String
@@ -6441,22 +6889,55 @@ input Offer_filter {
   removed_ends_with_nocase: String
   removed_not_ends_with: String
   removed_not_ends_with_nocase: String
+  removed_: Event_filter
   offerType: OfferType
   offerType_not: OfferType
   offerType_in: [OfferType!]
   offerType_not_in: [OfferType!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Offer_filter]
+  or: [Offer_filter]
 }
 
 enum Offer_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   open
   amount
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   created
+  created__id
+  created__amount
+  created__type
+  created__logNumber
+  created__blockNumber
+  created__blockHash
+  created__txHash
+  created__timestamp
   removed
+  removed__id
+  removed__amount
+  removed__type
+  removed__logNumber
+  removed__blockNumber
+  removed__blockHash
+  removed__txHash
+  removed__timestamp
   offerType
 }
 
@@ -6652,6 +7133,7 @@ input Punk_filter {
   wrapped_not: Boolean
   wrapped_in: [Boolean!]
   wrapped_not_in: [Boolean!]
+  events_: Event_filter
   currentAsk: String
   currentAsk_not: String
   currentAsk_gt: String
@@ -6812,27 +7294,122 @@ input Punk_filter {
   averageSalePrice_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Punk_filter]
+  or: [Punk_filter]
 }
 
 enum Punk_orderBy {
   id
   transferedTo
+  transferedTo__id
+  transferedTo__numberOfPunksOwned
+  transferedTo__numberOfPunksAssigned
+  transferedTo__numberOfTransfers
+  transferedTo__numberOfSales
+  transferedTo__numberOfPurchases
+  transferedTo__totalSpent
+  transferedTo__totalEarned
+  transferedTo__averageAmountSpent
+  transferedTo__accountUrl
   assignedTo
+  assignedTo__id
+  assignedTo__numberOfPunksOwned
+  assignedTo__numberOfPunksAssigned
+  assignedTo__numberOfTransfers
+  assignedTo__numberOfSales
+  assignedTo__numberOfPurchases
+  assignedTo__totalSpent
+  assignedTo__totalEarned
+  assignedTo__averageAmountSpent
+  assignedTo__accountUrl
   purchasedBy
+  purchasedBy__id
+  purchasedBy__numberOfPunksOwned
+  purchasedBy__numberOfPunksAssigned
+  purchasedBy__numberOfTransfers
+  purchasedBy__numberOfSales
+  purchasedBy__numberOfPurchases
+  purchasedBy__totalSpent
+  purchasedBy__totalEarned
+  purchasedBy__averageAmountSpent
+  purchasedBy__accountUrl
   metadata
+  metadata__id
+  metadata__tokenId
+  metadata__tokenURI
+  metadata__image
+  metadata__svg
+  metadata__contractURI
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   tokenId
   owner
+  owner__id
+  owner__numberOfPunksOwned
+  owner__numberOfPunksAssigned
+  owner__numberOfTransfers
+  owner__numberOfSales
+  owner__numberOfPurchases
+  owner__totalSpent
+  owner__totalEarned
+  owner__averageAmountSpent
+  owner__accountUrl
   wrapped
   events
   currentAsk
+  currentAsk__id
+  currentAsk__open
+  currentAsk__amount
+  currentAsk__offerType
   currentBid
+  currentBid__id
+  currentBid__open
+  currentBid__amount
+  currentBid__offerType
   currentAskCreated
+  currentAskCreated__id
+  currentAskCreated__amount
+  currentAskCreated__logNumber
+  currentAskCreated__type
+  currentAskCreated__blockNumber
+  currentAskCreated__blockHash
+  currentAskCreated__txHash
+  currentAskCreated__timestamp
   currentBidCreated
+  currentBidCreated__id
+  currentBidCreated__amount
+  currentBidCreated__logNumber
+  currentBidCreated__type
+  currentBidCreated__blockNumber
+  currentBidCreated__blockHash
+  currentBidCreated__txHash
+  currentBidCreated__timestamp
   numberOfTransfers
   numberOfSales
   currentAskRemoved
+  currentAskRemoved__id
+  currentAskRemoved__amount
+  currentAskRemoved__logNumber
+  currentAskRemoved__type
+  currentAskRemoved__blockNumber
+  currentAskRemoved__blockHash
+  currentAskRemoved__txHash
+  currentAskRemoved__timestamp
   currentBidRemoved
+  currentBidRemoved__id
+  currentBidRemoved__amount
+  currentBidRemoved__logNumber
+  currentBidRemoved__type
+  currentBidRemoved__blockNumber
+  currentBidRemoved__blockHash
+  currentBidRemoved__txHash
+  currentBidRemoved__timestamp
   totalAmountSpentOnPunk
   averageSalePrice
 }
@@ -6958,6 +7535,7 @@ input Sale_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -6980,12 +7558,20 @@ input Sale_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -7000,15 +7586,48 @@ input Sale_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Sale_filter]
+  or: [Sale_filter]
 }
 
 enum Sale_orderBy {
   id
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -7055,6 +7674,8 @@ input Trait_filter {
   numberOfNfts_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Trait_filter]
+  or: [Trait_filter]
 }
 
 enum Trait_orderBy {
@@ -7184,6 +7805,7 @@ input Transfer_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -7206,12 +7828,20 @@ input Transfer_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -7226,15 +7856,48 @@ input Transfer_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Transfer_filter]
+  or: [Transfer_filter]
 }
 
 enum Transfer_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -7362,6 +8025,7 @@ input Unwrap_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -7384,12 +8048,20 @@ input Unwrap_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -7404,15 +8076,48 @@ input Unwrap_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Unwrap_filter]
+  or: [Unwrap_filter]
 }
 
 enum Unwrap_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -7473,12 +8178,20 @@ input UserProxy_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -7493,11 +8206,23 @@ input UserProxy_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [UserProxy_filter]
+  or: [UserProxy_filter]
 }
 
 enum UserProxy_orderBy {
   id
   user
+  user__id
+  user__numberOfPunksOwned
+  user__numberOfPunksAssigned
+  user__numberOfTransfers
+  user__numberOfSales
+  user__numberOfPurchases
+  user__totalSpent
+  user__totalEarned
+  user__averageAmountSpent
+  user__accountUrl
   blockNumber
   blockHash
   txHash
@@ -7623,6 +8348,7 @@ input Wrap_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -7645,12 +8371,20 @@ input Wrap_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -7665,15 +8399,48 @@ input Wrap_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Wrap_filter]
+  or: [Wrap_filter]
 }
 
 enum Wrap_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber

--- a/apis/query/src/lib/graph/.graphclient/schema.graphql
+++ b/apis/query/src/lib/graph/.graphclient/schema.graphql
@@ -13,6 +13,112 @@ directive @subgraphId(id: String!) on OBJECT
 directive @derivedFrom(field: String!) on FIELD_DEFINITION
 
 type Query {
+  aggregation(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Aggregation
+  aggregations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Aggregation_orderBy
+    orderDirection: OrderDirection
+    where: Aggregation_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Aggregation!]!
+  depositor(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Depositor
+  depositors(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Depositor_orderBy
+    orderDirection: OrderDirection
+    where: Depositor_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Depositor!]!
+  dailyDeposit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): DailyDeposit
+  dailyDeposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: DailyDeposit_orderBy
+    orderDirection: OrderDirection
+    where: DailyDeposit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [DailyDeposit!]!
+  deposit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Deposit
+  deposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Deposit_orderBy
+    orderDirection: OrderDirection
+    where: Deposit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Deposit!]!
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
   delegateChange(
     id: ID!
     """
@@ -273,112 +379,6 @@ type Query {
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [VoteDailySnapshot!]!
-  """Access to subgraph metadata"""
-  _meta(block: Block_height): _Meta_
-  aggregation(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Aggregation
-  aggregations(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Aggregation_orderBy
-    orderDirection: OrderDirection
-    where: Aggregation_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Aggregation!]!
-  depositor(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Depositor
-  depositors(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Depositor_orderBy
-    orderDirection: OrderDirection
-    where: Depositor_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Depositor!]!
-  dailyDeposit(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): DailyDeposit
-  dailyDeposits(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: DailyDeposit_orderBy
-    orderDirection: OrderDirection
-    where: DailyDeposit_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [DailyDeposit!]!
-  deposit(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Deposit
-  deposits(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Deposit_orderBy
-    orderDirection: OrderDirection
-    where: Deposit_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Deposit!]!
   account(
     id: ID!
     """
@@ -980,6 +980,112 @@ type Query {
 }
 
 type Subscription {
+  aggregation(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Aggregation
+  aggregations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Aggregation_orderBy
+    orderDirection: OrderDirection
+    where: Aggregation_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Aggregation!]!
+  depositor(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Depositor
+  depositors(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Depositor_orderBy
+    orderDirection: OrderDirection
+    where: Depositor_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Depositor!]!
+  dailyDeposit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): DailyDeposit
+  dailyDeposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: DailyDeposit_orderBy
+    orderDirection: OrderDirection
+    where: DailyDeposit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [DailyDeposit!]!
+  deposit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Deposit
+  deposits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Deposit_orderBy
+    orderDirection: OrderDirection
+    where: Deposit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Deposit!]!
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
   delegateChange(
     id: ID!
     """
@@ -1240,112 +1346,6 @@ type Subscription {
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [VoteDailySnapshot!]!
-  """Access to subgraph metadata"""
-  _meta(block: Block_height): _Meta_
-  aggregation(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Aggregation
-  aggregations(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Aggregation_orderBy
-    orderDirection: OrderDirection
-    where: Aggregation_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Aggregation!]!
-  depositor(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Depositor
-  depositors(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Depositor_orderBy
-    orderDirection: OrderDirection
-    where: Depositor_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Depositor!]!
-  dailyDeposit(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): DailyDeposit
-  dailyDeposits(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: DailyDeposit_orderBy
-    orderDirection: OrderDirection
-    where: DailyDeposit_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [DailyDeposit!]!
-  deposit(
-    id: ID!
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Deposit
-  deposits(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Deposit_orderBy
-    orderDirection: OrderDirection
-    where: Deposit_filter
-    """
-    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Deposit!]!
   account(
     id: ID!
     """
@@ -1946,6 +1946,59 @@ type Subscription {
   ): [Offer!]!
 }
 
+type Aggregation {
+  id: ID!
+  totalDeposits: BigInt
+  totalDepositors: BigInt
+  totalAmountDeposited: BigInt
+}
+
+input Aggregation_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  totalDeposits: BigInt
+  totalDeposits_not: BigInt
+  totalDeposits_gt: BigInt
+  totalDeposits_lt: BigInt
+  totalDeposits_gte: BigInt
+  totalDeposits_lte: BigInt
+  totalDeposits_in: [BigInt!]
+  totalDeposits_not_in: [BigInt!]
+  totalDepositors: BigInt
+  totalDepositors_not: BigInt
+  totalDepositors_gt: BigInt
+  totalDepositors_lt: BigInt
+  totalDepositors_gte: BigInt
+  totalDepositors_lte: BigInt
+  totalDepositors_in: [BigInt!]
+  totalDepositors_not_in: [BigInt!]
+  totalAmountDeposited: BigInt
+  totalAmountDeposited_not: BigInt
+  totalAmountDeposited_gt: BigInt
+  totalAmountDeposited_lt: BigInt
+  totalAmountDeposited_gte: BigInt
+  totalAmountDeposited_lte: BigInt
+  totalAmountDeposited_in: [BigInt!]
+  totalAmountDeposited_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Aggregation_filter]
+  or: [Aggregation_filter]
+}
+
+enum Aggregation_orderBy {
+  id
+  totalDeposits
+  totalDepositors
+  totalAmountDeposited
+}
+
 scalar BigDecimal
 
 scalar BigInt
@@ -1961,6 +2014,250 @@ input Block_height {
 }
 
 scalar Bytes
+
+type DailyDeposit {
+  id: ID!
+  dailyAmountDeposited: BigInt
+  dailyDepositCount: BigInt
+}
+
+input DailyDeposit_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  dailyAmountDeposited: BigInt
+  dailyAmountDeposited_not: BigInt
+  dailyAmountDeposited_gt: BigInt
+  dailyAmountDeposited_lt: BigInt
+  dailyAmountDeposited_gte: BigInt
+  dailyAmountDeposited_lte: BigInt
+  dailyAmountDeposited_in: [BigInt!]
+  dailyAmountDeposited_not_in: [BigInt!]
+  dailyDepositCount: BigInt
+  dailyDepositCount_not: BigInt
+  dailyDepositCount_gt: BigInt
+  dailyDepositCount_lt: BigInt
+  dailyDepositCount_gte: BigInt
+  dailyDepositCount_lte: BigInt
+  dailyDepositCount_in: [BigInt!]
+  dailyDepositCount_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [DailyDeposit_filter]
+  or: [DailyDeposit_filter]
+}
+
+enum DailyDeposit_orderBy {
+  id
+  dailyAmountDeposited
+  dailyDepositCount
+}
+
+type Deposit {
+  id: ID!
+  dayID: String!
+  depositor: Depositor
+  pubkey: Bytes!
+  withdrawal_credentials: Bytes!
+  amount: BigInt!
+  timestamp: BigInt!
+}
+
+input Deposit_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  dayID: String
+  dayID_not: String
+  dayID_gt: String
+  dayID_lt: String
+  dayID_gte: String
+  dayID_lte: String
+  dayID_in: [String!]
+  dayID_not_in: [String!]
+  dayID_contains: String
+  dayID_contains_nocase: String
+  dayID_not_contains: String
+  dayID_not_contains_nocase: String
+  dayID_starts_with: String
+  dayID_starts_with_nocase: String
+  dayID_not_starts_with: String
+  dayID_not_starts_with_nocase: String
+  dayID_ends_with: String
+  dayID_ends_with_nocase: String
+  dayID_not_ends_with: String
+  dayID_not_ends_with_nocase: String
+  depositor: String
+  depositor_not: String
+  depositor_gt: String
+  depositor_lt: String
+  depositor_gte: String
+  depositor_lte: String
+  depositor_in: [String!]
+  depositor_not_in: [String!]
+  depositor_contains: String
+  depositor_contains_nocase: String
+  depositor_not_contains: String
+  depositor_not_contains_nocase: String
+  depositor_starts_with: String
+  depositor_starts_with_nocase: String
+  depositor_not_starts_with: String
+  depositor_not_starts_with_nocase: String
+  depositor_ends_with: String
+  depositor_ends_with_nocase: String
+  depositor_not_ends_with: String
+  depositor_not_ends_with_nocase: String
+  depositor_: Depositor_filter
+  pubkey: Bytes
+  pubkey_not: Bytes
+  pubkey_gt: Bytes
+  pubkey_lt: Bytes
+  pubkey_gte: Bytes
+  pubkey_lte: Bytes
+  pubkey_in: [Bytes!]
+  pubkey_not_in: [Bytes!]
+  pubkey_contains: Bytes
+  pubkey_not_contains: Bytes
+  withdrawal_credentials: Bytes
+  withdrawal_credentials_not: Bytes
+  withdrawal_credentials_gt: Bytes
+  withdrawal_credentials_lt: Bytes
+  withdrawal_credentials_gte: Bytes
+  withdrawal_credentials_lte: Bytes
+  withdrawal_credentials_in: [Bytes!]
+  withdrawal_credentials_not_in: [Bytes!]
+  withdrawal_credentials_contains: Bytes
+  withdrawal_credentials_not_contains: Bytes
+  amount: BigInt
+  amount_not: BigInt
+  amount_gt: BigInt
+  amount_lt: BigInt
+  amount_gte: BigInt
+  amount_lte: BigInt
+  amount_in: [BigInt!]
+  amount_not_in: [BigInt!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Deposit_filter]
+  or: [Deposit_filter]
+}
+
+enum Deposit_orderBy {
+  id
+  dayID
+  depositor
+  depositor__id
+  depositor__totalAmountDeposited
+  depositor__depositCount
+  pubkey
+  withdrawal_credentials
+  amount
+  timestamp
+}
+
+type Depositor {
+  id: ID!
+  totalAmountDeposited: BigInt
+  depositCount: BigInt
+  deposits(skip: Int = 0, first: Int = 100, orderBy: Deposit_orderBy, orderDirection: OrderDirection, where: Deposit_filter): [Deposit!]
+}
+
+input Depositor_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  totalAmountDeposited: BigInt
+  totalAmountDeposited_not: BigInt
+  totalAmountDeposited_gt: BigInt
+  totalAmountDeposited_lt: BigInt
+  totalAmountDeposited_gte: BigInt
+  totalAmountDeposited_lte: BigInt
+  totalAmountDeposited_in: [BigInt!]
+  totalAmountDeposited_not_in: [BigInt!]
+  depositCount: BigInt
+  depositCount_not: BigInt
+  depositCount_gt: BigInt
+  depositCount_lt: BigInt
+  depositCount_gte: BigInt
+  depositCount_lte: BigInt
+  depositCount_in: [BigInt!]
+  depositCount_not_in: [BigInt!]
+  deposits_: Deposit_filter
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Depositor_filter]
+  or: [Depositor_filter]
+}
+
+enum Depositor_orderBy {
+  id
+  totalAmountDeposited
+  depositCount
+  deposits
+}
+
+"""Defines the order direction, either ascending or descending"""
+enum OrderDirection {
+  asc
+  desc
+}
+
+type _Block_ {
+  """The hash of the block"""
+  hash: Bytes
+  """The block number"""
+  number: Int!
+  """Integer representation of the timestamp stored in blocks for the chain"""
+  timestamp: Int
+}
+
+"""The type for the top-level _meta field"""
+type _Meta_ {
+  """
+  Information about a specific subgraph block. The hash of the block
+  will be null if the _meta field has a block constraint that asks for
+  a block number. It will be filled if the _meta field has no block constraint
+  and therefore asks for the latest  block
+  
+  """
+  block: _Block_!
+  """The deployment ID"""
+  deployment: String!
+  """If `true`, the subgraph encountered indexing errors at some past block"""
+  hasIndexingErrors: Boolean!
+}
+
+enum _SubgraphErrorPolicy_ {
+  """Data will be returned even if the subgraph has indexing errors"""
+  allow
+  """
+  If the subgraph has indexing errors, data will be omitted. The default.
+  """
+  deny
+}
 
 type Delegate {
   """
@@ -2755,12 +3052,6 @@ enum Governance_orderBy {
   proposalsQueued
   proposalsExecuted
   proposalsCanceled
-}
-
-"""Defines the order direction, either ascending or descending"""
-enum OrderDirection {
-  asc
-  desc
 }
 
 type Proposal {
@@ -3715,297 +4006,6 @@ enum Vote_orderBy {
   block
   blockTime
   txnHash
-}
-
-type _Block_ {
-  """The hash of the block"""
-  hash: Bytes
-  """The block number"""
-  number: Int!
-  """Integer representation of the timestamp stored in blocks for the chain"""
-  timestamp: Int
-}
-
-"""The type for the top-level _meta field"""
-type _Meta_ {
-  """
-  Information about a specific subgraph block. The hash of the block
-  will be null if the _meta field has a block constraint that asks for
-  a block number. It will be filled if the _meta field has no block constraint
-  and therefore asks for the latest  block
-  
-  """
-  block: _Block_!
-  """The deployment ID"""
-  deployment: String!
-  """If `true`, the subgraph encountered indexing errors at some past block"""
-  hasIndexingErrors: Boolean!
-}
-
-enum _SubgraphErrorPolicy_ {
-  """Data will be returned even if the subgraph has indexing errors"""
-  allow
-  """
-  If the subgraph has indexing errors, data will be omitted. The default.
-  """
-  deny
-}
-
-type Aggregation {
-  id: ID!
-  totalDeposits: BigInt
-  totalDepositors: BigInt
-  totalAmountDeposited: BigInt
-}
-
-input Aggregation_filter {
-  id: ID
-  id_not: ID
-  id_gt: ID
-  id_lt: ID
-  id_gte: ID
-  id_lte: ID
-  id_in: [ID!]
-  id_not_in: [ID!]
-  totalDeposits: BigInt
-  totalDeposits_not: BigInt
-  totalDeposits_gt: BigInt
-  totalDeposits_lt: BigInt
-  totalDeposits_gte: BigInt
-  totalDeposits_lte: BigInt
-  totalDeposits_in: [BigInt!]
-  totalDeposits_not_in: [BigInt!]
-  totalDepositors: BigInt
-  totalDepositors_not: BigInt
-  totalDepositors_gt: BigInt
-  totalDepositors_lt: BigInt
-  totalDepositors_gte: BigInt
-  totalDepositors_lte: BigInt
-  totalDepositors_in: [BigInt!]
-  totalDepositors_not_in: [BigInt!]
-  totalAmountDeposited: BigInt
-  totalAmountDeposited_not: BigInt
-  totalAmountDeposited_gt: BigInt
-  totalAmountDeposited_lt: BigInt
-  totalAmountDeposited_gte: BigInt
-  totalAmountDeposited_lte: BigInt
-  totalAmountDeposited_in: [BigInt!]
-  totalAmountDeposited_not_in: [BigInt!]
-  """Filter for the block changed event."""
-  _change_block: BlockChangedFilter
-  and: [Aggregation_filter]
-  or: [Aggregation_filter]
-}
-
-enum Aggregation_orderBy {
-  id
-  totalDeposits
-  totalDepositors
-  totalAmountDeposited
-}
-
-type DailyDeposit {
-  id: ID!
-  dailyAmountDeposited: BigInt
-  dailyDepositCount: BigInt
-}
-
-input DailyDeposit_filter {
-  id: ID
-  id_not: ID
-  id_gt: ID
-  id_lt: ID
-  id_gte: ID
-  id_lte: ID
-  id_in: [ID!]
-  id_not_in: [ID!]
-  dailyAmountDeposited: BigInt
-  dailyAmountDeposited_not: BigInt
-  dailyAmountDeposited_gt: BigInt
-  dailyAmountDeposited_lt: BigInt
-  dailyAmountDeposited_gte: BigInt
-  dailyAmountDeposited_lte: BigInt
-  dailyAmountDeposited_in: [BigInt!]
-  dailyAmountDeposited_not_in: [BigInt!]
-  dailyDepositCount: BigInt
-  dailyDepositCount_not: BigInt
-  dailyDepositCount_gt: BigInt
-  dailyDepositCount_lt: BigInt
-  dailyDepositCount_gte: BigInt
-  dailyDepositCount_lte: BigInt
-  dailyDepositCount_in: [BigInt!]
-  dailyDepositCount_not_in: [BigInt!]
-  """Filter for the block changed event."""
-  _change_block: BlockChangedFilter
-  and: [DailyDeposit_filter]
-  or: [DailyDeposit_filter]
-}
-
-enum DailyDeposit_orderBy {
-  id
-  dailyAmountDeposited
-  dailyDepositCount
-}
-
-type Deposit {
-  id: ID!
-  dayID: String!
-  depositor: Depositor
-  pubkey: Bytes!
-  withdrawal_credentials: Bytes!
-  amount: BigInt!
-  timestamp: BigInt!
-}
-
-input Deposit_filter {
-  id: ID
-  id_not: ID
-  id_gt: ID
-  id_lt: ID
-  id_gte: ID
-  id_lte: ID
-  id_in: [ID!]
-  id_not_in: [ID!]
-  dayID: String
-  dayID_not: String
-  dayID_gt: String
-  dayID_lt: String
-  dayID_gte: String
-  dayID_lte: String
-  dayID_in: [String!]
-  dayID_not_in: [String!]
-  dayID_contains: String
-  dayID_contains_nocase: String
-  dayID_not_contains: String
-  dayID_not_contains_nocase: String
-  dayID_starts_with: String
-  dayID_starts_with_nocase: String
-  dayID_not_starts_with: String
-  dayID_not_starts_with_nocase: String
-  dayID_ends_with: String
-  dayID_ends_with_nocase: String
-  dayID_not_ends_with: String
-  dayID_not_ends_with_nocase: String
-  depositor: String
-  depositor_not: String
-  depositor_gt: String
-  depositor_lt: String
-  depositor_gte: String
-  depositor_lte: String
-  depositor_in: [String!]
-  depositor_not_in: [String!]
-  depositor_contains: String
-  depositor_contains_nocase: String
-  depositor_not_contains: String
-  depositor_not_contains_nocase: String
-  depositor_starts_with: String
-  depositor_starts_with_nocase: String
-  depositor_not_starts_with: String
-  depositor_not_starts_with_nocase: String
-  depositor_ends_with: String
-  depositor_ends_with_nocase: String
-  depositor_not_ends_with: String
-  depositor_not_ends_with_nocase: String
-  depositor_: Depositor_filter
-  pubkey: Bytes
-  pubkey_not: Bytes
-  pubkey_gt: Bytes
-  pubkey_lt: Bytes
-  pubkey_gte: Bytes
-  pubkey_lte: Bytes
-  pubkey_in: [Bytes!]
-  pubkey_not_in: [Bytes!]
-  pubkey_contains: Bytes
-  pubkey_not_contains: Bytes
-  withdrawal_credentials: Bytes
-  withdrawal_credentials_not: Bytes
-  withdrawal_credentials_gt: Bytes
-  withdrawal_credentials_lt: Bytes
-  withdrawal_credentials_gte: Bytes
-  withdrawal_credentials_lte: Bytes
-  withdrawal_credentials_in: [Bytes!]
-  withdrawal_credentials_not_in: [Bytes!]
-  withdrawal_credentials_contains: Bytes
-  withdrawal_credentials_not_contains: Bytes
-  amount: BigInt
-  amount_not: BigInt
-  amount_gt: BigInt
-  amount_lt: BigInt
-  amount_gte: BigInt
-  amount_lte: BigInt
-  amount_in: [BigInt!]
-  amount_not_in: [BigInt!]
-  timestamp: BigInt
-  timestamp_not: BigInt
-  timestamp_gt: BigInt
-  timestamp_lt: BigInt
-  timestamp_gte: BigInt
-  timestamp_lte: BigInt
-  timestamp_in: [BigInt!]
-  timestamp_not_in: [BigInt!]
-  """Filter for the block changed event."""
-  _change_block: BlockChangedFilter
-  and: [Deposit_filter]
-  or: [Deposit_filter]
-}
-
-enum Deposit_orderBy {
-  id
-  dayID
-  depositor
-  depositor__id
-  depositor__totalAmountDeposited
-  depositor__depositCount
-  pubkey
-  withdrawal_credentials
-  amount
-  timestamp
-}
-
-type Depositor {
-  id: ID!
-  totalAmountDeposited: BigInt
-  depositCount: BigInt
-  deposits(skip: Int = 0, first: Int = 100, orderBy: Deposit_orderBy, orderDirection: OrderDirection, where: Deposit_filter): [Deposit!]
-}
-
-input Depositor_filter {
-  id: ID
-  id_not: ID
-  id_gt: ID
-  id_lt: ID
-  id_gte: ID
-  id_lte: ID
-  id_in: [ID!]
-  id_not_in: [ID!]
-  totalAmountDeposited: BigInt
-  totalAmountDeposited_not: BigInt
-  totalAmountDeposited_gt: BigInt
-  totalAmountDeposited_lt: BigInt
-  totalAmountDeposited_gte: BigInt
-  totalAmountDeposited_lte: BigInt
-  totalAmountDeposited_in: [BigInt!]
-  totalAmountDeposited_not_in: [BigInt!]
-  depositCount: BigInt
-  depositCount_not: BigInt
-  depositCount_gt: BigInt
-  depositCount_lt: BigInt
-  depositCount_gte: BigInt
-  depositCount_lte: BigInt
-  depositCount_in: [BigInt!]
-  depositCount_not_in: [BigInt!]
-  deposits_: Deposit_filter
-  """Filter for the block changed event."""
-  _change_block: BlockChangedFilter
-  and: [Depositor_filter]
-  or: [Depositor_filter]
-}
-
-enum Depositor_orderBy {
-  id
-  totalAmountDeposited
-  depositCount
-  deposits
 }
 
 type Account {

--- a/apis/query/src/lib/graph/.graphclient/sources/beacon-depositors/introspectionSchema.ts
+++ b/apis/query/src/lib/graph/.graphclient/sources/beacon-depositors/introspectionSchema.ts
@@ -759,6 +759,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Aggregation_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Aggregation_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -1393,6 +1429,42 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "BlockChangedFilter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "DailyDeposit_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "DailyDeposit_filter"
+              }
             }
           },
           "directives": []
@@ -2387,6 +2459,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "pubkey_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "pubkey_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "pubkey_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "pubkey_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "pubkey_in"
           },
           "type": {
@@ -2475,6 +2607,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "withdrawal_credentials_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "withdrawal_credentials_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "withdrawal_credentials_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "withdrawal_credentials_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "withdrawal_credentials_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -2840,6 +3032,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Deposit_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Deposit_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -2872,6 +3100,30 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "depositor"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "depositor__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "depositor__totalAmountDeposited"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "depositor__depositCount"
           },
           "directives": []
         },
@@ -3512,6 +3764,42 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "BlockChangedFilter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Depositor_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Depositor_filter"
+              }
             }
           },
           "directives": []

--- a/apis/query/src/lib/graph/.graphclient/sources/beacon-depositors/schema.graphql
+++ b/apis/query/src/lib/graph/.graphclient/sources/beacon-depositors/schema.graphql
@@ -54,6 +54,8 @@ input Aggregation_filter {
   totalAmountDeposited_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Aggregation_filter]
+  or: [Aggregation_filter]
 }
 
 enum Aggregation_orderBy {
@@ -112,6 +114,8 @@ input DailyDeposit_filter {
   dailyDepositCount_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [DailyDeposit_filter]
+  or: [DailyDeposit_filter]
 }
 
 enum DailyDeposit_orderBy {
@@ -182,12 +186,20 @@ input Deposit_filter {
   depositor_: Depositor_filter
   pubkey: Bytes
   pubkey_not: Bytes
+  pubkey_gt: Bytes
+  pubkey_lt: Bytes
+  pubkey_gte: Bytes
+  pubkey_lte: Bytes
   pubkey_in: [Bytes!]
   pubkey_not_in: [Bytes!]
   pubkey_contains: Bytes
   pubkey_not_contains: Bytes
   withdrawal_credentials: Bytes
   withdrawal_credentials_not: Bytes
+  withdrawal_credentials_gt: Bytes
+  withdrawal_credentials_lt: Bytes
+  withdrawal_credentials_gte: Bytes
+  withdrawal_credentials_lte: Bytes
   withdrawal_credentials_in: [Bytes!]
   withdrawal_credentials_not_in: [Bytes!]
   withdrawal_credentials_contains: Bytes
@@ -210,12 +222,17 @@ input Deposit_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Deposit_filter]
+  or: [Deposit_filter]
 }
 
 enum Deposit_orderBy {
   id
   dayID
   depositor
+  depositor__id
+  depositor__totalAmountDeposited
+  depositor__depositCount
   pubkey
   withdrawal_credentials
   amount
@@ -257,6 +274,8 @@ input Depositor_filter {
   deposits_: Deposit_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Depositor_filter]
+  or: [Depositor_filter]
 }
 
 enum Depositor_orderBy {

--- a/apis/query/src/lib/graph/.graphclient/sources/beacon-depositors/types.ts
+++ b/apis/query/src/lib/graph/.graphclient/sources/beacon-depositors/types.ts
@@ -63,6 +63,8 @@ export type Aggregation_filter = {
   totalAmountDeposited_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Aggregation_filter>>>;
 };
 
 export type Aggregation_orderBy =
@@ -114,6 +116,8 @@ export type DailyDeposit_filter = {
   dailyDepositCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<DailyDeposit_filter>>>;
 };
 
 export type DailyDeposit_orderBy =
@@ -183,12 +187,20 @@ export type Deposit_filter = {
   depositor_?: InputMaybe<Depositor_filter>;
   pubkey?: InputMaybe<Scalars['Bytes']>;
   pubkey_not?: InputMaybe<Scalars['Bytes']>;
+  pubkey_gt?: InputMaybe<Scalars['Bytes']>;
+  pubkey_lt?: InputMaybe<Scalars['Bytes']>;
+  pubkey_gte?: InputMaybe<Scalars['Bytes']>;
+  pubkey_lte?: InputMaybe<Scalars['Bytes']>;
   pubkey_in?: InputMaybe<Array<Scalars['Bytes']>>;
   pubkey_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   pubkey_contains?: InputMaybe<Scalars['Bytes']>;
   pubkey_not_contains?: InputMaybe<Scalars['Bytes']>;
   withdrawal_credentials?: InputMaybe<Scalars['Bytes']>;
   withdrawal_credentials_not?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_gt?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_lt?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_gte?: InputMaybe<Scalars['Bytes']>;
+  withdrawal_credentials_lte?: InputMaybe<Scalars['Bytes']>;
   withdrawal_credentials_in?: InputMaybe<Array<Scalars['Bytes']>>;
   withdrawal_credentials_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   withdrawal_credentials_contains?: InputMaybe<Scalars['Bytes']>;
@@ -211,12 +223,17 @@ export type Deposit_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Deposit_filter>>>;
 };
 
 export type Deposit_orderBy =
   | 'id'
   | 'dayID'
   | 'depositor'
+  | 'depositor__id'
+  | 'depositor__totalAmountDeposited'
+  | 'depositor__depositCount'
   | 'pubkey'
   | 'withdrawal_credentials'
   | 'amount'
@@ -266,6 +283,8 @@ export type Depositor_filter = {
   deposits_?: InputMaybe<Deposit_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Depositor_filter>>>;
 };
 
 export type Depositor_orderBy =

--- a/apis/query/src/lib/graph/.graphclient/sources/cryptopunks/introspectionSchema.ts
+++ b/apis/query/src/lib/graph/.graphclient/sources/cryptopunks/introspectionSchema.ts
@@ -1328,6 +1328,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "id_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "id_in"
           },
           "type": {
@@ -1422,6 +1482,21 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "Sale_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nftsOwned_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
             }
           },
           "directives": []
@@ -2885,6 +2960,42 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "BlockChangedFilter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Account_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Account_filter"
+              }
             }
           },
           "directives": []
@@ -5406,6 +5517,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "logNumber"
           },
           "type": {
@@ -5772,6 +5898,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "blockHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "blockHash_in"
           },
           "type": {
@@ -5860,6 +6046,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "txHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -6093,6 +6339,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AskCreated_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AskCreated_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -6124,6 +6406,86 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "to"
           },
           "directives": []
@@ -6132,7 +6494,119 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "to__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "ask"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "ask__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "ask__open"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "ask__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "ask__offerType"
           },
           "directives": []
         },
@@ -6156,7 +6630,95 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "contract__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__symbol"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSupply"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalAmountTraded"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__imageHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "nft"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
           },
           "directives": []
         },
@@ -8382,6 +8944,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "logNumber"
           },
           "type": {
@@ -8748,6 +9325,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "blockHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "blockHash_in"
           },
           "type": {
@@ -8836,6 +9473,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "txHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -9069,6 +9766,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AskRemoved_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AskRemoved_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -9100,6 +9833,38 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "ask__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "ask__open"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "ask__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "ask__offerType"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "from"
           },
           "directives": []
@@ -9108,7 +9873,167 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "to"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__accountUrl"
           },
           "directives": []
         },
@@ -9132,7 +10057,95 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "contract__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__symbol"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSupply"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalAmountTraded"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__imageHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "nft"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
           },
           "directives": []
         },
@@ -10173,6 +11186,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "created"
           },
           "type": {
@@ -10477,6 +11505,21 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Event_filter"
             }
           },
           "directives": []
@@ -10797,6 +11840,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "removed_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Event_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "offerType"
           },
           "type": {
@@ -10884,6 +11942,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Ask_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Ask_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -10915,6 +12009,86 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "open"
           },
           "directives": []
@@ -10939,6 +12113,38 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "created"
           },
           "directives": []
@@ -10947,7 +12153,135 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "created__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__type"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__logNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__blockHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__txHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__timestamp"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "removed"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__type"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__logNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__blockHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__txHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__timestamp"
           },
           "directives": []
         },
@@ -11988,6 +13322,21 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
             }
           },
           "directives": []
@@ -13148,6 +14497,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "blockHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "blockHash_in"
           },
           "type": {
@@ -13236,6 +14645,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "txHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -13469,6 +14938,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Assign_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Assign_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -13500,6 +15005,62 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "contract__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__symbol"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSupply"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalAmountTraded"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__imageHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "nft"
           },
           "directives": []
@@ -13508,7 +15069,119 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "to"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__accountUrl"
           },
           "directives": []
         },
@@ -13525,6 +15198,86 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "from"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
           },
           "directives": []
         },
@@ -15939,6 +17692,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "logNumber"
           },
           "type": {
@@ -16305,6 +18073,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "blockHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "blockHash_in"
           },
           "type": {
@@ -16393,6 +18221,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "txHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -16626,6 +18514,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "BidCreated_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "BidCreated_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -16657,6 +18581,86 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "to"
           },
           "directives": []
@@ -16665,7 +18669,119 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "to__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "bid"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "bid__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "bid__open"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "bid__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "bid__offerType"
           },
           "directives": []
         },
@@ -16689,7 +18805,95 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "contract__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__symbol"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSupply"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalAmountTraded"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__imageHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "nft"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
           },
           "directives": []
         },
@@ -18915,6 +21119,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "logNumber"
           },
           "type": {
@@ -19281,6 +21500,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "blockHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "blockHash_in"
           },
           "type": {
@@ -19369,6 +21648,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "txHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -19602,6 +21941,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "BidRemoved_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "BidRemoved_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -19633,7 +22008,167 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "to"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__accountUrl"
           },
           "directives": []
         },
@@ -19657,6 +22192,38 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "bid__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "bid__open"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "bid__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "bid__offerType"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "contract"
           },
           "directives": []
@@ -19665,7 +22232,95 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "contract__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__symbol"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSupply"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalAmountTraded"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__imageHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "nft"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
           },
           "directives": []
         },
@@ -20706,6 +23361,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "created"
           },
           "type": {
@@ -21010,6 +23680,21 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Event_filter"
             }
           },
           "directives": []
@@ -21330,6 +24015,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "removed_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Event_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "offerType"
           },
           "type": {
@@ -21417,6 +24117,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Bid_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Bid_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -21448,6 +24184,86 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "open"
           },
           "directives": []
@@ -21472,6 +24288,38 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "created"
           },
           "directives": []
@@ -21480,7 +24328,135 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "created__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__type"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__logNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__blockHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__txHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__timestamp"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "removed"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__type"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__logNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__blockHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__txHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__timestamp"
           },
           "directives": []
         },
@@ -23878,6 +26854,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "blockHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "blockHash_in"
           },
           "type": {
@@ -23966,6 +27002,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "txHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -24199,6 +27295,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "CToken_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "CToken_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -24230,7 +27362,167 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "to"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__accountUrl"
           },
           "directives": []
         },
@@ -25961,6 +29253,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Contract_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Contract_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -26367,6 +29695,42 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "BlockChangedFilter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "EpnsNotificationCounter_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "EpnsNotificationCounter_filter"
+              }
             }
           },
           "directives": []
@@ -27398,6 +30762,42 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "BlockChangedFilter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "EpnsPushNotification_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "EpnsPushNotification_filter"
+              }
             }
           },
           "directives": []
@@ -29336,6 +32736,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "type"
           },
           "type": {
@@ -29702,6 +33117,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "blockHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "blockHash_in"
           },
           "type": {
@@ -29790,6 +33265,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "txHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -30023,6 +33558,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Event_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Event_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -30054,6 +33625,62 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "contract__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__symbol"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSupply"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalAmountTraded"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__imageHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "from"
           },
           "directives": []
@@ -30062,7 +33689,167 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "to"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__accountUrl"
           },
           "directives": []
         },
@@ -30079,6 +33866,38 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "nft"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
           },
           "directives": []
         },
@@ -32416,6 +36235,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "MetaData_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "MetaData_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -32480,6 +36335,62 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "punk"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "punk__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "punk__tokenId"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "punk__wrapped"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "punk__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "punk__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "punk__totalAmountSpentOnPunk"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "punk__averageSalePrice"
           },
           "directives": []
         },
@@ -33980,6 +37891,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "events_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Event_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "currentAsk"
           },
           "type": {
@@ -34649,6 +38575,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "NFT_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "NFT_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -34673,6 +38635,62 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "contract"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__symbol"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSupply"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalAmountTraded"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__imageHash"
           },
           "directives": []
         },
@@ -34712,6 +38730,86 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "owner__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "events"
           },
           "directives": []
@@ -34728,7 +38826,71 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "currentAsk__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAsk__open"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAsk__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAsk__offerType"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "currentBid"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBid__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBid__open"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBid__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBid__offerType"
           },
           "directives": []
         }
@@ -35931,6 +40093,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "created"
           },
           "type": {
@@ -36235,6 +40412,21 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Event_filter"
             }
           },
           "directives": []
@@ -36555,6 +40747,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "removed_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Event_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "offerType"
           },
           "type": {
@@ -36642,6 +40849,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Offer_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Offer_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -36673,6 +40916,86 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "open"
           },
           "directives": []
@@ -36697,6 +41020,38 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "created"
           },
           "directives": []
@@ -36705,7 +41060,135 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "created__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__type"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__logNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__blockHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__txHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "created__timestamp"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "removed"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__type"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__logNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__blockHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__txHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "removed__timestamp"
           },
           "directives": []
         },
@@ -39616,6 +44099,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "events_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Event_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "currentAsk"
           },
           "type": {
@@ -42121,6 +46619,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Punk_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Punk_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -42152,7 +46686,167 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "transferedTo__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transferedTo__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transferedTo__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transferedTo__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transferedTo__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transferedTo__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transferedTo__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transferedTo__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transferedTo__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transferedTo__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "assignedTo"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "assignedTo__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "assignedTo__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "assignedTo__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "assignedTo__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "assignedTo__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "assignedTo__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "assignedTo__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "assignedTo__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "assignedTo__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "assignedTo__accountUrl"
           },
           "directives": []
         },
@@ -42168,6 +46862,86 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "purchasedBy__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "purchasedBy__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "purchasedBy__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "purchasedBy__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "purchasedBy__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "purchasedBy__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "purchasedBy__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "purchasedBy__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "purchasedBy__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "purchasedBy__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "metadata"
           },
           "directives": []
@@ -42176,7 +46950,111 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "metadata__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "metadata__tokenId"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "metadata__tokenURI"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "metadata__image"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "metadata__svg"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "metadata__contractURI"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "contract"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__symbol"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSupply"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalAmountTraded"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__imageHash"
           },
           "directives": []
         },
@@ -42193,6 +47071,86 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "owner"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "owner__accountUrl"
           },
           "directives": []
         },
@@ -42224,7 +47182,71 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "currentAsk__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAsk__open"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAsk__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAsk__offerType"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "currentBid"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBid__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBid__open"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBid__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBid__offerType"
           },
           "directives": []
         },
@@ -42240,7 +47262,135 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "currentAskCreated__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskCreated__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskCreated__logNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskCreated__type"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskCreated__blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskCreated__blockHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskCreated__txHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskCreated__timestamp"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "currentBidCreated"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidCreated__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidCreated__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidCreated__logNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidCreated__type"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidCreated__blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidCreated__blockHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidCreated__txHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidCreated__timestamp"
           },
           "directives": []
         },
@@ -42272,7 +47422,135 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "currentAskRemoved__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskRemoved__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskRemoved__logNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskRemoved__type"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskRemoved__blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskRemoved__blockHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskRemoved__txHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentAskRemoved__timestamp"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "currentBidRemoved"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidRemoved__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidRemoved__amount"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidRemoved__logNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidRemoved__type"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidRemoved__blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidRemoved__blockHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidRemoved__txHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "currentBidRemoved__timestamp"
           },
           "directives": []
         },
@@ -49647,6 +54925,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "logNumber"
           },
           "type": {
@@ -50013,6 +55306,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "blockHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "blockHash_in"
           },
           "type": {
@@ -50101,6 +55454,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "txHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -50334,6 +55747,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Sale_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Sale_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -50365,6 +55814,86 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "to__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "amount"
           },
           "directives": []
@@ -50381,6 +55910,86 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "contract"
           },
           "directives": []
@@ -50389,7 +55998,95 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "contract__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__symbol"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSupply"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalAmountTraded"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__imageHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "nft"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
           },
           "directives": []
         },
@@ -56556,6 +62253,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Trait_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Trait_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -58427,6 +64160,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "logNumber"
           },
           "type": {
@@ -58793,6 +64541,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "blockHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "blockHash_in"
           },
           "type": {
@@ -58881,6 +64689,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "txHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -59114,6 +64982,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Transfer_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Transfer_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -59145,7 +65049,167 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "to"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__accountUrl"
           },
           "directives": []
         },
@@ -59169,7 +65233,95 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "contract__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__symbol"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSupply"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalAmountTraded"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__imageHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "nft"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
           },
           "directives": []
         },
@@ -61044,6 +67196,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "logNumber"
           },
           "type": {
@@ -61410,6 +67577,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "blockHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "blockHash_in"
           },
           "type": {
@@ -61498,6 +67725,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "txHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -61731,6 +68018,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Unwrap_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Unwrap_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -61762,7 +68085,167 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "to"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__accountUrl"
           },
           "directives": []
         },
@@ -61786,7 +68269,95 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "contract__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__symbol"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSupply"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalAmountTraded"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__imageHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "nft"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
           },
           "directives": []
         },
@@ -62613,6 +69184,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "blockHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "blockHash_in"
           },
           "type": {
@@ -62701,6 +69332,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "txHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -62934,6 +69625,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "UserProxy_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "UserProxy_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -62958,6 +69685,86 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "user"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "user__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "user__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "user__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "user__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "user__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "user__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "user__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "user__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "user__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "user__accountUrl"
           },
           "directives": []
         },
@@ -64816,6 +71623,21 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "nft_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NFT_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "logNumber"
           },
           "type": {
@@ -65182,6 +72004,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "blockHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "blockHash_in"
           },
           "type": {
@@ -65270,6 +72152,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "txHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "txHash_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -65503,6 +72445,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Wrap_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Wrap_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -65534,7 +72512,167 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "from__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "from__accountUrl"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "to"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksOwned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPunksAssigned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__numberOfPurchases"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__totalEarned"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__averageAmountSpent"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "to__accountUrl"
           },
           "directives": []
         },
@@ -65558,7 +72696,95 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "contract__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__symbol"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSupply"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__totalAmountTraded"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "contract__imageHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "nft"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfTransfers"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__numberOfSales"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "nft__tokenId"
           },
           "directives": []
         },
@@ -65661,6 +72887,27 @@ const schemaAST = {
                 "kind": "Name",
                 "value": "Int"
               }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "description": {
+            "kind": "StringValue",
+            "value": "Integer representation of the timestamp stored in blocks for the chain",
+            "block": true
+          },
+          "name": {
+            "kind": "Name",
+            "value": "timestamp"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
             }
           },
           "directives": []

--- a/apis/query/src/lib/graph/.graphclient/sources/cryptopunks/schema.graphql
+++ b/apis/query/src/lib/graph/.graphclient/sources/cryptopunks/schema.graphql
@@ -54,12 +54,17 @@ type Account {
 input Account_filter {
   id: Bytes
   id_not: Bytes
+  id_gt: Bytes
+  id_lt: Bytes
+  id_gte: Bytes
+  id_lte: Bytes
   id_in: [Bytes!]
   id_not_in: [Bytes!]
   id_contains: Bytes
   id_not_contains: Bytes
   punksOwned_: Punk_filter
   bought_: Sale_filter
+  nftsOwned_: NFT_filter
   assigned_: Assign_filter
   sent_: Transfer_filter
   received_: Transfer_filter
@@ -151,6 +156,8 @@ input Account_filter {
   accountUrl_not_ends_with_nocase: String
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Account_filter]
+  or: [Account_filter]
 }
 
 enum Account_orderBy {
@@ -333,6 +340,7 @@ input AskCreated_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -355,12 +363,20 @@ input AskCreated_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -375,16 +391,53 @@ input AskCreated_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [AskCreated_filter]
+  or: [AskCreated_filter]
 }
 
 enum AskCreated_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   ask
+  ask__id
+  ask__open
+  ask__amount
+  ask__offerType
   amount
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -535,6 +588,7 @@ input AskRemoved_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -557,12 +611,20 @@ input AskRemoved_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -577,16 +639,53 @@ input AskRemoved_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [AskRemoved_filter]
+  or: [AskRemoved_filter]
 }
 
 enum AskRemoved_orderBy {
   id
   ask
+  ask__id
+  ask__open
+  ask__amount
+  ask__offerType
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -657,6 +756,7 @@ input Ask_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   created: String
   created_not: String
   created_gt: String
@@ -677,6 +777,7 @@ input Ask_filter {
   created_ends_with_nocase: String
   created_not_ends_with: String
   created_not_ends_with_nocase: String
+  created_: Event_filter
   removed: String
   removed_not: String
   removed_gt: String
@@ -697,22 +798,55 @@ input Ask_filter {
   removed_ends_with_nocase: String
   removed_not_ends_with: String
   removed_not_ends_with_nocase: String
+  removed_: Event_filter
   offerType: OfferType
   offerType_not: OfferType
   offerType_in: [OfferType!]
   offerType_not_in: [OfferType!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Ask_filter]
+  or: [Ask_filter]
 }
 
 enum Ask_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   open
   amount
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   created
+  created__id
+  created__amount
+  created__type
+  created__logNumber
+  created__blockNumber
+  created__blockHash
+  created__txHash
+  created__timestamp
   removed
+  removed__id
+  removed__amount
+  removed__type
+  removed__logNumber
+  removed__blockNumber
+  removed__blockHash
+  removed__txHash
+  removed__timestamp
   offerType
 }
 
@@ -785,6 +919,7 @@ input Assign_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   to: String
   to_not: String
   to_gt: String
@@ -857,12 +992,20 @@ input Assign_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -877,15 +1020,48 @@ input Assign_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Assign_filter]
+  or: [Assign_filter]
 }
 
 enum Assign_orderBy {
   id
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   type
   logNumber
   blockNumber
@@ -1053,6 +1229,7 @@ input BidCreated_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -1075,12 +1252,20 @@ input BidCreated_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -1095,16 +1280,53 @@ input BidCreated_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [BidCreated_filter]
+  or: [BidCreated_filter]
 }
 
 enum BidCreated_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   bid
+  bid__id
+  bid__open
+  bid__amount
+  bid__offerType
   amount
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -1255,6 +1477,7 @@ input BidRemoved_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -1277,12 +1500,20 @@ input BidRemoved_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -1297,16 +1528,53 @@ input BidRemoved_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [BidRemoved_filter]
+  or: [BidRemoved_filter]
 }
 
 enum BidRemoved_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   bid
+  bid__id
+  bid__open
+  bid__amount
+  bid__offerType
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -1377,6 +1645,7 @@ input Bid_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   created: String
   created_not: String
   created_gt: String
@@ -1397,6 +1666,7 @@ input Bid_filter {
   created_ends_with_nocase: String
   created_not_ends_with: String
   created_not_ends_with_nocase: String
+  created_: Event_filter
   removed: String
   removed_not: String
   removed_gt: String
@@ -1417,22 +1687,55 @@ input Bid_filter {
   removed_ends_with_nocase: String
   removed_not_ends_with: String
   removed_not_ends_with_nocase: String
+  removed_: Event_filter
   offerType: OfferType
   offerType_not: OfferType
   offerType_in: [OfferType!]
   offerType_not_in: [OfferType!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Bid_filter]
+  or: [Bid_filter]
 }
 
 enum Bid_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   open
   amount
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   created
+  created__id
+  created__amount
+  created__type
+  created__logNumber
+  created__blockNumber
+  created__blockHash
+  created__txHash
+  created__timestamp
   removed
+  removed__id
+  removed__amount
+  removed__type
+  removed__logNumber
+  removed__blockNumber
+  removed__blockHash
+  removed__txHash
+  removed__timestamp
   offerType
 }
 
@@ -1602,12 +1905,20 @@ input CToken_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -1622,12 +1933,34 @@ input CToken_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [CToken_filter]
+  or: [CToken_filter]
 }
 
 enum CToken_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   owner
   amount
   punkId
@@ -1750,6 +2083,8 @@ input Contract_filter {
   imageHash_not_ends_with_nocase: String
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Contract_filter]
+  or: [Contract_filter]
 }
 
 enum Contract_orderBy {
@@ -1786,6 +2121,8 @@ input EpnsNotificationCounter_filter {
   totalCount_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [EpnsNotificationCounter_filter]
+  or: [EpnsNotificationCounter_filter]
 }
 
 enum EpnsNotificationCounter_orderBy {
@@ -1859,6 +2196,8 @@ input EpnsPushNotification_filter {
   notification_not_ends_with_nocase: String
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [EpnsPushNotification_filter]
+  or: [EpnsPushNotification_filter]
 }
 
 enum EpnsPushNotification_orderBy {
@@ -1998,6 +2337,7 @@ input Event_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   type: EventType
   type_not: EventType
   type_in: [EventType!]
@@ -2020,12 +2360,20 @@ input Event_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -2040,15 +2388,48 @@ input Event_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Event_filter]
+  or: [Event_filter]
 }
 
 enum Event_orderBy {
   id
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   type
   logNumber
   blockNumber
@@ -2201,6 +2582,8 @@ input MetaData_filter {
   traits_: Trait_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [MetaData_filter]
+  or: [MetaData_filter]
 }
 
 enum MetaData_orderBy {
@@ -2211,6 +2594,13 @@ enum MetaData_orderBy {
   svg
   contractURI
   punk
+  punk__id
+  punk__tokenId
+  punk__wrapped
+  punk__numberOfTransfers
+  punk__numberOfSales
+  punk__totalAmountSpentOnPunk
+  punk__averageSalePrice
   traits
 }
 
@@ -2307,6 +2697,7 @@ input NFT_filter {
   owner_not_ends_with: String
   owner_not_ends_with_nocase: String
   owner_: Account_filter
+  events_: Event_filter
   currentAsk: String
   currentAsk_not: String
   currentAsk_gt: String
@@ -2351,18 +2742,45 @@ input NFT_filter {
   currentBid_: Bid_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [NFT_filter]
+  or: [NFT_filter]
 }
 
 enum NFT_orderBy {
   id
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   numberOfTransfers
   numberOfSales
   tokenId
   owner
+  owner__id
+  owner__numberOfPunksOwned
+  owner__numberOfPunksAssigned
+  owner__numberOfTransfers
+  owner__numberOfSales
+  owner__numberOfPurchases
+  owner__totalSpent
+  owner__totalEarned
+  owner__averageAmountSpent
+  owner__accountUrl
   events
   currentAsk
+  currentAsk__id
+  currentAsk__open
+  currentAsk__amount
+  currentAsk__offerType
   currentBid
+  currentBid__id
+  currentBid__open
+  currentBid__amount
+  currentBid__offerType
 }
 
 interface Offer {
@@ -2449,6 +2867,7 @@ input Offer_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   created: String
   created_not: String
   created_gt: String
@@ -2469,6 +2888,7 @@ input Offer_filter {
   created_ends_with_nocase: String
   created_not_ends_with: String
   created_not_ends_with_nocase: String
+  created_: Event_filter
   removed: String
   removed_not: String
   removed_gt: String
@@ -2489,22 +2909,55 @@ input Offer_filter {
   removed_ends_with_nocase: String
   removed_not_ends_with: String
   removed_not_ends_with_nocase: String
+  removed_: Event_filter
   offerType: OfferType
   offerType_not: OfferType
   offerType_in: [OfferType!]
   offerType_not_in: [OfferType!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Offer_filter]
+  or: [Offer_filter]
 }
 
 enum Offer_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   open
   amount
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   created
+  created__id
+  created__amount
+  created__type
+  created__logNumber
+  created__blockNumber
+  created__blockHash
+  created__txHash
+  created__timestamp
   removed
+  removed__id
+  removed__amount
+  removed__type
+  removed__logNumber
+  removed__blockNumber
+  removed__blockHash
+  removed__txHash
+  removed__timestamp
   offerType
 }
 
@@ -2706,6 +3159,7 @@ input Punk_filter {
   wrapped_not: Boolean
   wrapped_in: [Boolean!]
   wrapped_not_in: [Boolean!]
+  events_: Event_filter
   currentAsk: String
   currentAsk_not: String
   currentAsk_gt: String
@@ -2866,27 +3320,122 @@ input Punk_filter {
   averageSalePrice_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Punk_filter]
+  or: [Punk_filter]
 }
 
 enum Punk_orderBy {
   id
   transferedTo
+  transferedTo__id
+  transferedTo__numberOfPunksOwned
+  transferedTo__numberOfPunksAssigned
+  transferedTo__numberOfTransfers
+  transferedTo__numberOfSales
+  transferedTo__numberOfPurchases
+  transferedTo__totalSpent
+  transferedTo__totalEarned
+  transferedTo__averageAmountSpent
+  transferedTo__accountUrl
   assignedTo
+  assignedTo__id
+  assignedTo__numberOfPunksOwned
+  assignedTo__numberOfPunksAssigned
+  assignedTo__numberOfTransfers
+  assignedTo__numberOfSales
+  assignedTo__numberOfPurchases
+  assignedTo__totalSpent
+  assignedTo__totalEarned
+  assignedTo__averageAmountSpent
+  assignedTo__accountUrl
   purchasedBy
+  purchasedBy__id
+  purchasedBy__numberOfPunksOwned
+  purchasedBy__numberOfPunksAssigned
+  purchasedBy__numberOfTransfers
+  purchasedBy__numberOfSales
+  purchasedBy__numberOfPurchases
+  purchasedBy__totalSpent
+  purchasedBy__totalEarned
+  purchasedBy__averageAmountSpent
+  purchasedBy__accountUrl
   metadata
+  metadata__id
+  metadata__tokenId
+  metadata__tokenURI
+  metadata__image
+  metadata__svg
+  metadata__contractURI
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   tokenId
   owner
+  owner__id
+  owner__numberOfPunksOwned
+  owner__numberOfPunksAssigned
+  owner__numberOfTransfers
+  owner__numberOfSales
+  owner__numberOfPurchases
+  owner__totalSpent
+  owner__totalEarned
+  owner__averageAmountSpent
+  owner__accountUrl
   wrapped
   events
   currentAsk
+  currentAsk__id
+  currentAsk__open
+  currentAsk__amount
+  currentAsk__offerType
   currentBid
+  currentBid__id
+  currentBid__open
+  currentBid__amount
+  currentBid__offerType
   currentAskCreated
+  currentAskCreated__id
+  currentAskCreated__amount
+  currentAskCreated__logNumber
+  currentAskCreated__type
+  currentAskCreated__blockNumber
+  currentAskCreated__blockHash
+  currentAskCreated__txHash
+  currentAskCreated__timestamp
   currentBidCreated
+  currentBidCreated__id
+  currentBidCreated__amount
+  currentBidCreated__logNumber
+  currentBidCreated__type
+  currentBidCreated__blockNumber
+  currentBidCreated__blockHash
+  currentBidCreated__txHash
+  currentBidCreated__timestamp
   numberOfTransfers
   numberOfSales
   currentAskRemoved
+  currentAskRemoved__id
+  currentAskRemoved__amount
+  currentAskRemoved__logNumber
+  currentAskRemoved__type
+  currentAskRemoved__blockNumber
+  currentAskRemoved__blockHash
+  currentAskRemoved__txHash
+  currentAskRemoved__timestamp
   currentBidRemoved
+  currentBidRemoved__id
+  currentBidRemoved__amount
+  currentBidRemoved__logNumber
+  currentBidRemoved__type
+  currentBidRemoved__blockNumber
+  currentBidRemoved__blockHash
+  currentBidRemoved__txHash
+  currentBidRemoved__timestamp
   totalAmountSpentOnPunk
   averageSalePrice
 }
@@ -3615,6 +4164,7 @@ input Sale_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -3637,12 +4187,20 @@ input Sale_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -3657,15 +4215,48 @@ input Sale_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Sale_filter]
+  or: [Sale_filter]
 }
 
 enum Sale_orderBy {
   id
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -4315,6 +4906,8 @@ input Trait_filter {
   numberOfNfts_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Trait_filter]
+  or: [Trait_filter]
 }
 
 enum Trait_orderBy {
@@ -4444,6 +5037,7 @@ input Transfer_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -4466,12 +5060,20 @@ input Transfer_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -4486,15 +5088,48 @@ input Transfer_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Transfer_filter]
+  or: [Transfer_filter]
 }
 
 enum Transfer_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -4622,6 +5257,7 @@ input Unwrap_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -4644,12 +5280,20 @@ input Unwrap_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -4664,15 +5308,48 @@ input Unwrap_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Unwrap_filter]
+  or: [Unwrap_filter]
 }
 
 enum Unwrap_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -4733,12 +5410,20 @@ input UserProxy_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -4753,11 +5438,23 @@ input UserProxy_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [UserProxy_filter]
+  or: [UserProxy_filter]
 }
 
 enum UserProxy_orderBy {
   id
   user
+  user__id
+  user__numberOfPunksOwned
+  user__numberOfPunksAssigned
+  user__numberOfTransfers
+  user__numberOfSales
+  user__numberOfPurchases
+  user__totalSpent
+  user__totalEarned
+  user__averageAmountSpent
+  user__accountUrl
   blockNumber
   blockHash
   txHash
@@ -4883,6 +5580,7 @@ input Wrap_filter {
   nft_ends_with_nocase: String
   nft_not_ends_with: String
   nft_not_ends_with_nocase: String
+  nft_: NFT_filter
   logNumber: BigInt
   logNumber_not: BigInt
   logNumber_gt: BigInt
@@ -4905,12 +5603,20 @@ input Wrap_filter {
   blockNumber_not_in: [BigInt!]
   blockHash: Bytes
   blockHash_not: Bytes
+  blockHash_gt: Bytes
+  blockHash_lt: Bytes
+  blockHash_gte: Bytes
+  blockHash_lte: Bytes
   blockHash_in: [Bytes!]
   blockHash_not_in: [Bytes!]
   blockHash_contains: Bytes
   blockHash_not_contains: Bytes
   txHash: Bytes
   txHash_not: Bytes
+  txHash_gt: Bytes
+  txHash_lt: Bytes
+  txHash_gte: Bytes
+  txHash_lte: Bytes
   txHash_in: [Bytes!]
   txHash_not_in: [Bytes!]
   txHash_contains: Bytes
@@ -4925,15 +5631,48 @@ input Wrap_filter {
   timestamp_not_in: [BigInt!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Wrap_filter]
+  or: [Wrap_filter]
 }
 
 enum Wrap_orderBy {
   id
   from
+  from__id
+  from__numberOfPunksOwned
+  from__numberOfPunksAssigned
+  from__numberOfTransfers
+  from__numberOfSales
+  from__numberOfPurchases
+  from__totalSpent
+  from__totalEarned
+  from__averageAmountSpent
+  from__accountUrl
   to
+  to__id
+  to__numberOfPunksOwned
+  to__numberOfPunksAssigned
+  to__numberOfTransfers
+  to__numberOfSales
+  to__numberOfPurchases
+  to__totalSpent
+  to__totalEarned
+  to__averageAmountSpent
+  to__accountUrl
   amount
   contract
+  contract__id
+  contract__symbol
+  contract__name
+  contract__totalSupply
+  contract__totalSales
+  contract__totalAmountTraded
+  contract__imageHash
   nft
+  nft__id
+  nft__numberOfTransfers
+  nft__numberOfSales
+  nft__tokenId
   logNumber
   type
   blockNumber
@@ -4947,6 +5686,8 @@ type _Block_ {
   hash: Bytes
   """The block number"""
   number: Int!
+  """Integer representation of the timestamp stored in blocks for the chain"""
+  timestamp: Int
 }
 
 """The type for the top-level _meta field"""

--- a/apis/query/src/lib/graph/.graphclient/sources/cryptopunks/types.ts
+++ b/apis/query/src/lib/graph/.graphclient/sources/cryptopunks/types.ts
@@ -135,12 +135,17 @@ export type AccountasksArgs = {
 export type Account_filter = {
   id?: InputMaybe<Scalars['Bytes']>;
   id_not?: InputMaybe<Scalars['Bytes']>;
+  id_gt?: InputMaybe<Scalars['Bytes']>;
+  id_lt?: InputMaybe<Scalars['Bytes']>;
+  id_gte?: InputMaybe<Scalars['Bytes']>;
+  id_lte?: InputMaybe<Scalars['Bytes']>;
   id_in?: InputMaybe<Array<Scalars['Bytes']>>;
   id_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   id_contains?: InputMaybe<Scalars['Bytes']>;
   id_not_contains?: InputMaybe<Scalars['Bytes']>;
   punksOwned_?: InputMaybe<Punk_filter>;
   bought_?: InputMaybe<Sale_filter>;
+  nftsOwned_?: InputMaybe<NFT_filter>;
   assigned_?: InputMaybe<Assign_filter>;
   sent_?: InputMaybe<Transfer_filter>;
   received_?: InputMaybe<Transfer_filter>;
@@ -232,6 +237,8 @@ export type Account_filter = {
   accountUrl_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Account_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Account_filter>>>;
 };
 
 export type Account_orderBy =
@@ -413,6 +420,7 @@ export type AskCreated_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -435,12 +443,20 @@ export type AskCreated_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -455,16 +471,53 @@ export type AskCreated_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<AskCreated_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<AskCreated_filter>>>;
 };
 
 export type AskCreated_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'ask'
+  | 'ask__id'
+  | 'ask__open'
+  | 'ask__amount'
+  | 'ask__offerType'
   | 'amount'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -614,6 +667,7 @@ export type AskRemoved_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -636,12 +690,20 @@ export type AskRemoved_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -656,16 +718,53 @@ export type AskRemoved_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<AskRemoved_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<AskRemoved_filter>>>;
 };
 
 export type AskRemoved_orderBy =
   | 'id'
   | 'ask'
+  | 'ask__id'
+  | 'ask__open'
+  | 'ask__amount'
+  | 'ask__offerType'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -735,6 +834,7 @@ export type Ask_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   created?: InputMaybe<Scalars['String']>;
   created_not?: InputMaybe<Scalars['String']>;
   created_gt?: InputMaybe<Scalars['String']>;
@@ -755,6 +855,7 @@ export type Ask_filter = {
   created_ends_with_nocase?: InputMaybe<Scalars['String']>;
   created_not_ends_with?: InputMaybe<Scalars['String']>;
   created_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  created_?: InputMaybe<Event_filter>;
   removed?: InputMaybe<Scalars['String']>;
   removed_not?: InputMaybe<Scalars['String']>;
   removed_gt?: InputMaybe<Scalars['String']>;
@@ -775,22 +876,55 @@ export type Ask_filter = {
   removed_ends_with_nocase?: InputMaybe<Scalars['String']>;
   removed_not_ends_with?: InputMaybe<Scalars['String']>;
   removed_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  removed_?: InputMaybe<Event_filter>;
   offerType?: InputMaybe<OfferType>;
   offerType_not?: InputMaybe<OfferType>;
   offerType_in?: InputMaybe<Array<OfferType>>;
   offerType_not_in?: InputMaybe<Array<OfferType>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Ask_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Ask_filter>>>;
 };
 
 export type Ask_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'open'
   | 'amount'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'created'
+  | 'created__id'
+  | 'created__amount'
+  | 'created__type'
+  | 'created__logNumber'
+  | 'created__blockNumber'
+  | 'created__blockHash'
+  | 'created__txHash'
+  | 'created__timestamp'
   | 'removed'
+  | 'removed__id'
+  | 'removed__amount'
+  | 'removed__type'
+  | 'removed__logNumber'
+  | 'removed__blockNumber'
+  | 'removed__blockHash'
+  | 'removed__txHash'
+  | 'removed__timestamp'
   | 'offerType';
 
 export type Assign = Event & {
@@ -862,6 +996,7 @@ export type Assign_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   to?: InputMaybe<Scalars['String']>;
   to_not?: InputMaybe<Scalars['String']>;
   to_gt?: InputMaybe<Scalars['String']>;
@@ -934,12 +1069,20 @@ export type Assign_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -954,15 +1097,48 @@ export type Assign_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Assign_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Assign_filter>>>;
 };
 
 export type Assign_orderBy =
   | 'id'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'type'
   | 'logNumber'
   | 'blockNumber'
@@ -1129,6 +1305,7 @@ export type BidCreated_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -1151,12 +1328,20 @@ export type BidCreated_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -1171,16 +1356,53 @@ export type BidCreated_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<BidCreated_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<BidCreated_filter>>>;
 };
 
 export type BidCreated_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'bid'
+  | 'bid__id'
+  | 'bid__open'
+  | 'bid__amount'
+  | 'bid__offerType'
   | 'amount'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -1330,6 +1552,7 @@ export type BidRemoved_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -1352,12 +1575,20 @@ export type BidRemoved_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -1372,16 +1603,53 @@ export type BidRemoved_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<BidRemoved_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<BidRemoved_filter>>>;
 };
 
 export type BidRemoved_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'bid'
+  | 'bid__id'
+  | 'bid__open'
+  | 'bid__amount'
+  | 'bid__offerType'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -1451,6 +1719,7 @@ export type Bid_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   created?: InputMaybe<Scalars['String']>;
   created_not?: InputMaybe<Scalars['String']>;
   created_gt?: InputMaybe<Scalars['String']>;
@@ -1471,6 +1740,7 @@ export type Bid_filter = {
   created_ends_with_nocase?: InputMaybe<Scalars['String']>;
   created_not_ends_with?: InputMaybe<Scalars['String']>;
   created_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  created_?: InputMaybe<Event_filter>;
   removed?: InputMaybe<Scalars['String']>;
   removed_not?: InputMaybe<Scalars['String']>;
   removed_gt?: InputMaybe<Scalars['String']>;
@@ -1491,22 +1761,55 @@ export type Bid_filter = {
   removed_ends_with_nocase?: InputMaybe<Scalars['String']>;
   removed_not_ends_with?: InputMaybe<Scalars['String']>;
   removed_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  removed_?: InputMaybe<Event_filter>;
   offerType?: InputMaybe<OfferType>;
   offerType_not?: InputMaybe<OfferType>;
   offerType_in?: InputMaybe<Array<OfferType>>;
   offerType_not_in?: InputMaybe<Array<OfferType>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Bid_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Bid_filter>>>;
 };
 
 export type Bid_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'open'
   | 'amount'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'created'
+  | 'created__id'
+  | 'created__amount'
+  | 'created__type'
+  | 'created__logNumber'
+  | 'created__blockNumber'
+  | 'created__blockHash'
+  | 'created__txHash'
+  | 'created__timestamp'
   | 'removed'
+  | 'removed__id'
+  | 'removed__amount'
+  | 'removed__type'
+  | 'removed__logNumber'
+  | 'removed__blockNumber'
+  | 'removed__blockHash'
+  | 'removed__txHash'
+  | 'removed__timestamp'
   | 'offerType';
 
 export type BlockChangedFilter = {
@@ -1669,12 +1972,20 @@ export type CToken_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -1689,12 +2000,34 @@ export type CToken_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<CToken_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<CToken_filter>>>;
 };
 
 export type CToken_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'owner'
   | 'amount'
   | 'punkId'
@@ -1816,6 +2149,8 @@ export type Contract_filter = {
   imageHash_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Contract_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Contract_filter>>>;
 };
 
 export type Contract_orderBy =
@@ -1851,6 +2186,8 @@ export type EpnsNotificationCounter_filter = {
   totalCount_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<EpnsNotificationCounter_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<EpnsNotificationCounter_filter>>>;
 };
 
 export type EpnsNotificationCounter_orderBy =
@@ -1923,6 +2260,8 @@ export type EpnsPushNotification_filter = {
   notification_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<EpnsPushNotification_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<EpnsPushNotification_filter>>>;
 };
 
 export type EpnsPushNotification_orderBy =
@@ -2060,6 +2399,7 @@ export type Event_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   type?: InputMaybe<EventType>;
   type_not?: InputMaybe<EventType>;
   type_in?: InputMaybe<Array<EventType>>;
@@ -2082,12 +2422,20 @@ export type Event_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -2102,15 +2450,48 @@ export type Event_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Event_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Event_filter>>>;
 };
 
 export type Event_orderBy =
   | 'id'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'type'
   | 'logNumber'
   | 'blockNumber'
@@ -2271,6 +2652,8 @@ export type MetaData_filter = {
   traits_?: InputMaybe<Trait_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<MetaData_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<MetaData_filter>>>;
 };
 
 export type MetaData_orderBy =
@@ -2281,6 +2664,13 @@ export type MetaData_orderBy =
   | 'svg'
   | 'contractURI'
   | 'punk'
+  | 'punk__id'
+  | 'punk__tokenId'
+  | 'punk__wrapped'
+  | 'punk__numberOfTransfers'
+  | 'punk__numberOfSales'
+  | 'punk__totalAmountSpentOnPunk'
+  | 'punk__averageSalePrice'
   | 'traits';
 
 export type NFT = {
@@ -2385,6 +2775,7 @@ export type NFT_filter = {
   owner_not_ends_with?: InputMaybe<Scalars['String']>;
   owner_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
   owner_?: InputMaybe<Account_filter>;
+  events_?: InputMaybe<Event_filter>;
   currentAsk?: InputMaybe<Scalars['String']>;
   currentAsk_not?: InputMaybe<Scalars['String']>;
   currentAsk_gt?: InputMaybe<Scalars['String']>;
@@ -2429,18 +2820,45 @@ export type NFT_filter = {
   currentBid_?: InputMaybe<Bid_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<NFT_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<NFT_filter>>>;
 };
 
 export type NFT_orderBy =
   | 'id'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'numberOfTransfers'
   | 'numberOfSales'
   | 'tokenId'
   | 'owner'
+  | 'owner__id'
+  | 'owner__numberOfPunksOwned'
+  | 'owner__numberOfPunksAssigned'
+  | 'owner__numberOfTransfers'
+  | 'owner__numberOfSales'
+  | 'owner__numberOfPurchases'
+  | 'owner__totalSpent'
+  | 'owner__totalEarned'
+  | 'owner__averageAmountSpent'
+  | 'owner__accountUrl'
   | 'events'
   | 'currentAsk'
-  | 'currentBid';
+  | 'currentAsk__id'
+  | 'currentAsk__open'
+  | 'currentAsk__amount'
+  | 'currentAsk__offerType'
+  | 'currentBid'
+  | 'currentBid__id'
+  | 'currentBid__open'
+  | 'currentBid__amount'
+  | 'currentBid__offerType';
 
 export type Offer = {
   id: Scalars['ID'];
@@ -2525,6 +2943,7 @@ export type Offer_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   created?: InputMaybe<Scalars['String']>;
   created_not?: InputMaybe<Scalars['String']>;
   created_gt?: InputMaybe<Scalars['String']>;
@@ -2545,6 +2964,7 @@ export type Offer_filter = {
   created_ends_with_nocase?: InputMaybe<Scalars['String']>;
   created_not_ends_with?: InputMaybe<Scalars['String']>;
   created_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  created_?: InputMaybe<Event_filter>;
   removed?: InputMaybe<Scalars['String']>;
   removed_not?: InputMaybe<Scalars['String']>;
   removed_gt?: InputMaybe<Scalars['String']>;
@@ -2565,22 +2985,55 @@ export type Offer_filter = {
   removed_ends_with_nocase?: InputMaybe<Scalars['String']>;
   removed_not_ends_with?: InputMaybe<Scalars['String']>;
   removed_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  removed_?: InputMaybe<Event_filter>;
   offerType?: InputMaybe<OfferType>;
   offerType_not?: InputMaybe<OfferType>;
   offerType_in?: InputMaybe<Array<OfferType>>;
   offerType_not_in?: InputMaybe<Array<OfferType>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Offer_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Offer_filter>>>;
 };
 
 export type Offer_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'open'
   | 'amount'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'created'
+  | 'created__id'
+  | 'created__amount'
+  | 'created__type'
+  | 'created__logNumber'
+  | 'created__blockNumber'
+  | 'created__blockHash'
+  | 'created__txHash'
+  | 'created__timestamp'
   | 'removed'
+  | 'removed__id'
+  | 'removed__amount'
+  | 'removed__type'
+  | 'removed__logNumber'
+  | 'removed__blockNumber'
+  | 'removed__blockHash'
+  | 'removed__txHash'
+  | 'removed__timestamp'
   | 'offerType';
 
 /** Defines the order direction, either ascending or descending */
@@ -2787,6 +3240,7 @@ export type Punk_filter = {
   wrapped_not?: InputMaybe<Scalars['Boolean']>;
   wrapped_in?: InputMaybe<Array<Scalars['Boolean']>>;
   wrapped_not_in?: InputMaybe<Array<Scalars['Boolean']>>;
+  events_?: InputMaybe<Event_filter>;
   currentAsk?: InputMaybe<Scalars['String']>;
   currentAsk_not?: InputMaybe<Scalars['String']>;
   currentAsk_gt?: InputMaybe<Scalars['String']>;
@@ -2947,27 +3401,122 @@ export type Punk_filter = {
   averageSalePrice_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Punk_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Punk_filter>>>;
 };
 
 export type Punk_orderBy =
   | 'id'
   | 'transferedTo'
+  | 'transferedTo__id'
+  | 'transferedTo__numberOfPunksOwned'
+  | 'transferedTo__numberOfPunksAssigned'
+  | 'transferedTo__numberOfTransfers'
+  | 'transferedTo__numberOfSales'
+  | 'transferedTo__numberOfPurchases'
+  | 'transferedTo__totalSpent'
+  | 'transferedTo__totalEarned'
+  | 'transferedTo__averageAmountSpent'
+  | 'transferedTo__accountUrl'
   | 'assignedTo'
+  | 'assignedTo__id'
+  | 'assignedTo__numberOfPunksOwned'
+  | 'assignedTo__numberOfPunksAssigned'
+  | 'assignedTo__numberOfTransfers'
+  | 'assignedTo__numberOfSales'
+  | 'assignedTo__numberOfPurchases'
+  | 'assignedTo__totalSpent'
+  | 'assignedTo__totalEarned'
+  | 'assignedTo__averageAmountSpent'
+  | 'assignedTo__accountUrl'
   | 'purchasedBy'
+  | 'purchasedBy__id'
+  | 'purchasedBy__numberOfPunksOwned'
+  | 'purchasedBy__numberOfPunksAssigned'
+  | 'purchasedBy__numberOfTransfers'
+  | 'purchasedBy__numberOfSales'
+  | 'purchasedBy__numberOfPurchases'
+  | 'purchasedBy__totalSpent'
+  | 'purchasedBy__totalEarned'
+  | 'purchasedBy__averageAmountSpent'
+  | 'purchasedBy__accountUrl'
   | 'metadata'
+  | 'metadata__id'
+  | 'metadata__tokenId'
+  | 'metadata__tokenURI'
+  | 'metadata__image'
+  | 'metadata__svg'
+  | 'metadata__contractURI'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'tokenId'
   | 'owner'
+  | 'owner__id'
+  | 'owner__numberOfPunksOwned'
+  | 'owner__numberOfPunksAssigned'
+  | 'owner__numberOfTransfers'
+  | 'owner__numberOfSales'
+  | 'owner__numberOfPurchases'
+  | 'owner__totalSpent'
+  | 'owner__totalEarned'
+  | 'owner__averageAmountSpent'
+  | 'owner__accountUrl'
   | 'wrapped'
   | 'events'
   | 'currentAsk'
+  | 'currentAsk__id'
+  | 'currentAsk__open'
+  | 'currentAsk__amount'
+  | 'currentAsk__offerType'
   | 'currentBid'
+  | 'currentBid__id'
+  | 'currentBid__open'
+  | 'currentBid__amount'
+  | 'currentBid__offerType'
   | 'currentAskCreated'
+  | 'currentAskCreated__id'
+  | 'currentAskCreated__amount'
+  | 'currentAskCreated__logNumber'
+  | 'currentAskCreated__type'
+  | 'currentAskCreated__blockNumber'
+  | 'currentAskCreated__blockHash'
+  | 'currentAskCreated__txHash'
+  | 'currentAskCreated__timestamp'
   | 'currentBidCreated'
+  | 'currentBidCreated__id'
+  | 'currentBidCreated__amount'
+  | 'currentBidCreated__logNumber'
+  | 'currentBidCreated__type'
+  | 'currentBidCreated__blockNumber'
+  | 'currentBidCreated__blockHash'
+  | 'currentBidCreated__txHash'
+  | 'currentBidCreated__timestamp'
   | 'numberOfTransfers'
   | 'numberOfSales'
   | 'currentAskRemoved'
+  | 'currentAskRemoved__id'
+  | 'currentAskRemoved__amount'
+  | 'currentAskRemoved__logNumber'
+  | 'currentAskRemoved__type'
+  | 'currentAskRemoved__blockNumber'
+  | 'currentAskRemoved__blockHash'
+  | 'currentAskRemoved__txHash'
+  | 'currentAskRemoved__timestamp'
   | 'currentBidRemoved'
+  | 'currentBidRemoved__id'
+  | 'currentBidRemoved__amount'
+  | 'currentBidRemoved__logNumber'
+  | 'currentBidRemoved__type'
+  | 'currentBidRemoved__blockNumber'
+  | 'currentBidRemoved__blockHash'
+  | 'currentBidRemoved__txHash'
+  | 'currentBidRemoved__timestamp'
   | 'totalAmountSpentOnPunk'
   | 'averageSalePrice';
 
@@ -3562,6 +4111,7 @@ export type Sale_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -3584,12 +4134,20 @@ export type Sale_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -3604,15 +4162,48 @@ export type Sale_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Sale_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Sale_filter>>>;
 };
 
 export type Sale_orderBy =
   | 'id'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -4136,6 +4727,8 @@ export type Trait_filter = {
   numberOfNfts_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Trait_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Trait_filter>>>;
 };
 
 export type Trait_orderBy =
@@ -4264,6 +4857,7 @@ export type Transfer_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -4286,12 +4880,20 @@ export type Transfer_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -4306,15 +4908,48 @@ export type Transfer_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Transfer_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Transfer_filter>>>;
 };
 
 export type Transfer_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -4441,6 +5076,7 @@ export type Unwrap_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -4463,12 +5099,20 @@ export type Unwrap_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -4483,15 +5127,48 @@ export type Unwrap_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Unwrap_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Unwrap_filter>>>;
 };
 
 export type Unwrap_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -4551,12 +5228,20 @@ export type UserProxy_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -4571,11 +5256,23 @@ export type UserProxy_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<UserProxy_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<UserProxy_filter>>>;
 };
 
 export type UserProxy_orderBy =
   | 'id'
   | 'user'
+  | 'user__id'
+  | 'user__numberOfPunksOwned'
+  | 'user__numberOfPunksAssigned'
+  | 'user__numberOfTransfers'
+  | 'user__numberOfSales'
+  | 'user__numberOfPurchases'
+  | 'user__totalSpent'
+  | 'user__totalEarned'
+  | 'user__averageAmountSpent'
+  | 'user__accountUrl'
   | 'blockNumber'
   | 'blockHash'
   | 'txHash'
@@ -4700,6 +5397,7 @@ export type Wrap_filter = {
   nft_ends_with_nocase?: InputMaybe<Scalars['String']>;
   nft_not_ends_with?: InputMaybe<Scalars['String']>;
   nft_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  nft_?: InputMaybe<NFT_filter>;
   logNumber?: InputMaybe<Scalars['BigInt']>;
   logNumber_not?: InputMaybe<Scalars['BigInt']>;
   logNumber_gt?: InputMaybe<Scalars['BigInt']>;
@@ -4722,12 +5420,20 @@ export type Wrap_filter = {
   blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   blockHash?: InputMaybe<Scalars['Bytes']>;
   blockHash_not?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lt?: InputMaybe<Scalars['Bytes']>;
+  blockHash_gte?: InputMaybe<Scalars['Bytes']>;
+  blockHash_lte?: InputMaybe<Scalars['Bytes']>;
   blockHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   blockHash_contains?: InputMaybe<Scalars['Bytes']>;
   blockHash_not_contains?: InputMaybe<Scalars['Bytes']>;
   txHash?: InputMaybe<Scalars['Bytes']>;
   txHash_not?: InputMaybe<Scalars['Bytes']>;
+  txHash_gt?: InputMaybe<Scalars['Bytes']>;
+  txHash_lt?: InputMaybe<Scalars['Bytes']>;
+  txHash_gte?: InputMaybe<Scalars['Bytes']>;
+  txHash_lte?: InputMaybe<Scalars['Bytes']>;
   txHash_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
   txHash_contains?: InputMaybe<Scalars['Bytes']>;
@@ -4742,15 +5448,48 @@ export type Wrap_filter = {
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Wrap_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Wrap_filter>>>;
 };
 
 export type Wrap_orderBy =
   | 'id'
   | 'from'
+  | 'from__id'
+  | 'from__numberOfPunksOwned'
+  | 'from__numberOfPunksAssigned'
+  | 'from__numberOfTransfers'
+  | 'from__numberOfSales'
+  | 'from__numberOfPurchases'
+  | 'from__totalSpent'
+  | 'from__totalEarned'
+  | 'from__averageAmountSpent'
+  | 'from__accountUrl'
   | 'to'
+  | 'to__id'
+  | 'to__numberOfPunksOwned'
+  | 'to__numberOfPunksAssigned'
+  | 'to__numberOfTransfers'
+  | 'to__numberOfSales'
+  | 'to__numberOfPurchases'
+  | 'to__totalSpent'
+  | 'to__totalEarned'
+  | 'to__averageAmountSpent'
+  | 'to__accountUrl'
   | 'amount'
   | 'contract'
+  | 'contract__id'
+  | 'contract__symbol'
+  | 'contract__name'
+  | 'contract__totalSupply'
+  | 'contract__totalSales'
+  | 'contract__totalAmountTraded'
+  | 'contract__imageHash'
   | 'nft'
+  | 'nft__id'
+  | 'nft__numberOfTransfers'
+  | 'nft__numberOfSales'
+  | 'nft__tokenId'
   | 'logNumber'
   | 'type'
   | 'blockNumber'
@@ -4763,6 +5502,8 @@ export type _Block_ = {
   hash?: Maybe<Scalars['Bytes']>;
   /** The block number */
   number: Scalars['Int'];
+  /** Integer representation of the timestamp stored in blocks for the chain */
+  timestamp?: Maybe<Scalars['Int']>;
 };
 
 /** The type for the top-level _meta field */

--- a/apis/query/src/lib/graph/beacon-depositors.graphql
+++ b/apis/query/src/lib/graph/beacon-depositors.graphql
@@ -1,5 +1,6 @@
-query BeaconDepositors {
-  depositors {
+# https://thegraph.com/explorer/subgraphs/3QQgWcYVRWS7ni5nCftJzSnZELTZMVQV6HTiSZKKmZBZ?view=Playground&chain=mainnet
+query BeaconDepositors($skip: Int) {
+  depositors(skip: $skip) {
     id
   }
 }

--- a/apis/query/src/lib/graph/beacon-depositors.graphql
+++ b/apis/query/src/lib/graph/beacon-depositors.graphql
@@ -1,6 +1,6 @@
 # https://thegraph.com/explorer/subgraphs/3QQgWcYVRWS7ni5nCftJzSnZELTZMVQV6HTiSZKKmZBZ?view=Playground&chain=mainnet
 query BeaconDepositors($skip: Int) {
-  depositors(skip: $skip) {
+  depositors(first: 1000, skip: $skip) {
     id
   }
 }

--- a/apis/query/src/lib/graph/proposal-voters.graphql
+++ b/apis/query/src/lib/graph/proposal-voters.graphql
@@ -1,4 +1,4 @@
-query VotersPerProposal($id: ID!, $choice: VoteChoice) {
+query VotersPerProposal($id: ID!, $choice: VoteChoice, $skip: Int) {
   proposal(
     id: $id
   ) {

--- a/apis/query/src/lib/graph/proposal-voters.graphql
+++ b/apis/query/src/lib/graph/proposal-voters.graphql
@@ -3,7 +3,7 @@ query VotersPerProposal($id: ID!, $choice: VoteChoice, $skip: Int) {
     id: $id
   ) {
     state
-    votes(where: {choice: $choice}) {
+    votes(first:1000, skip: $skip, where: {choice: $choice}) {
       voter {
         id
       }

--- a/apis/query/src/lib/graph/punk.graphql
+++ b/apis/query/src/lib/graph/punk.graphql
@@ -1,6 +1,6 @@
 # https://thegraph.com/explorer/subgraphs/YqMJatbgbqy1GodtbYZv4U9NzyaScCgSF7CAE5ivAM7?view=Playground
-query PunkOwners {
-    punks {
+query PunkOwners($skip: Int) {
+    punks(first: 1000, skip: $skip) {
         owner {
             id
         }

--- a/apis/query/test/unit/AnonymitySetController.test.ts
+++ b/apis/query/test/unit/AnonymitySetController.test.ts
@@ -99,7 +99,7 @@ describe('AnonymitySet Controller', () => {
           { choice: 'FO', id: faker.random.numeric(78) },
           {
             choice: 'FOR',
-            id: faker.random.numeric(77),
+            id: faker.random.numeric(76),
           },
           { choice: 'FOR' },
           { id: faker.random.numeric(78) },


### PR DESCRIPTION
Closes #90 

# Description

The graph queries return 1000 records max by default. So it is necessary to send multiple requests to get the complete list of results.

## Behavior Changes

[//]: # 'Delete this section if not applicable'

| Before | After |
| ------ | ----- |
|   The following end points: `/beacon`, `/punks`, `/ens-proposal-voters` return lists of 100 addresses only     | Complete list is returned (e.g +3700 for `/punks`, +90000 for `/beacon` )      |

# How has this been tested?

Run server locally (`pn run start.dev`).  
Go to 
- http://localhost:3000/beacon
- http://localhost:3000/punks
- http://localhost:3000/ens-proposal-voters?id=90476529665364161211265365238121921179703522228680648046371476645353679539653&choice=FOR

Full list of results is returned. Console shows that the results are aggregated.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] All existing CI checks pass
  - My code compiles
  - My code follows the style guidelines of this project (code is linted and formatted)
  - My code doesn't break existing tests
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I added a reviewer for this pull request.
- [x] I have assigned myself to this pull request.
- [x] I have added the appropriate label(s) to this pull request.
