### PR TITLE
:recycle::heavy_minus_sign: Use dune api key instead of custom `dune-ts` lib

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -32,7 +32,10 @@ overrides:
     rules:
       '@typescript-eslint/restrict-template-expressions': off
   - files:
-      ['apis/query/src/api/controllers/requests/getEthBalanceAnonSetQuery.ts']
+      [
+        'apis/query/src/api/controllers/requests/getEthBalanceAnonSetQuery.ts',
+        'apis/query/src/api/repositories/DuneRepository.ts',
+      ]
     rules:
       '@typescript-eslint/no-inferrable-types': off
   - files: ['apis/prove/generated/*.js']

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -46,8 +46,7 @@ jobs:
 
       - name: Run tests
         env:
-          DUNE_USERNAME: foo
-          DUNE_PASSWORD: bar
+          DUNE_API_KEY: foo
         run: pnpm t
 
       - name: Coveralls

--- a/apis/query/package.json
+++ b/apis/query/package.json
@@ -15,6 +15,7 @@
     "~": "dist/lib"
   },
   "dependencies": {
+    "@cowprotocol/ts-dune-client": "^0.0.1",
     "@google-cloud/bigquery": "^6.0.3",
     "@graphprotocol/client-cli": "^2.2.15",
     "@graphql-mesh/cache-localforage": "^0.7.3",
@@ -30,7 +31,6 @@
     "@whatwg-node/fetch": "^0.5.3",
     "class-validator": "^0.14.0",
     "cors": "^2.8.5",
-    "dune-ts": "^1.1.4",
     "ethers": "^5.7.2",
     "express": "^4.18.2",
     "graphql": "^16.6.0",

--- a/apis/query/src/api/repositories/DuneRepository.ts
+++ b/apis/query/src/api/repositories/DuneRepository.ts
@@ -23,7 +23,7 @@ export class DuneRepository {
   }) {
     const parameters = [
       QueryParameter.number('min', min),
-      QueryParameter.text('tokenAddress', tokenAddress),
+      QueryParameter.text('tokenAddress', `"${tokenAddress}"`),
     ]
 
     return this.dune.refresh(Query.Erc20, parameters)

--- a/apis/query/src/api/repositories/DuneRepository.ts
+++ b/apis/query/src/api/repositories/DuneRepository.ts
@@ -1,4 +1,4 @@
-import { Dune, ParameterType } from 'dune-ts'
+import { DuneClient as Dune, QueryParameter } from '@cowprotocol/ts-dune-client'
 import { Service } from 'typedi'
 
 export enum Query {
@@ -8,33 +8,10 @@ export enum Query {
 @Service()
 export class DuneRepository {
   dune: Dune
-
   constructor() {
-    this.dune = new Dune({
-      password: process.env.DUNE_PASSWORD,
-      username: process.env.DUNE_USERNAME,
-    })
-  }
-
-  private resetDune() {
-    console.log('reset dune')
-    this.dune = new Dune({
-      password: process.env.DUNE_PASSWORD,
-      username: process.env.DUNE_USERNAME,
-    })
-  }
-
-  private async _queryErc20Balance({
-    min,
-    tokenAddress,
-  }: {
-    min: string
-    tokenAddress: string
-  }) {
-    return this.dune.query(Query.Erc20, [
-      { key: 'tokenAddress', type: ParameterType.Text, value: tokenAddress },
-      { key: 'min', type: ParameterType.Number, value: min },
-    ])
+    const { DUNE_API_KEY } = process.env
+    if (DUNE_API_KEY === undefined) throw new Error('missing dune api key')
+    this.dune = new Dune(DUNE_API_KEY)
   }
 
   public async queryErc20Balance({
@@ -44,14 +21,11 @@ export class DuneRepository {
     min: string
     tokenAddress: string
   }) {
-    try {
-      return await this._queryErc20Balance({ min, tokenAddress })
-    } catch (err) {
-      console.log({ executionId: this.dune.executionId })
-      console.log('DuneRepository.queryErc20Balance() error:', err)
-      // TODO: not sure if this is reliable fix, look into dune-ts instead (cache of cookies/bearer token?)
-      this.resetDune()
-      return this._queryErc20Balance({ min, tokenAddress })
-    }
+    const parameters = [
+      QueryParameter.number('min', min),
+      QueryParameter.text('tokenAddress', tokenAddress),
+    ]
+
+    return this.dune.refresh(Query.Erc20, parameters)
   }
 }

--- a/apis/query/src/api/services/QueryService.ts
+++ b/apis/query/src/api/services/QueryService.ts
@@ -32,9 +32,9 @@ export class QueryService {
   }: getErc20BalanceAnonSetQuery) {
     return this.duneRepository
       .queryErc20Balance({ min, tokenAddress })
-      .then(({ data }) => {
+      .then(({ result }) => {
         this.logger.info('Get ERC20-balance based anonymity set')
-        return data.map((row) => row.address)
+        return result?.rows?.map((row) => row.address) ?? []
       })
   }
 

--- a/apis/query/test/unit/DuneRepository.test.ts
+++ b/apis/query/test/unit/DuneRepository.test.ts
@@ -1,9 +1,45 @@
+import { faker } from '@faker-js/faker'
 import { DuneRepository } from '@repositories'
 
+jest.setTimeout(30_000)
+
 describe('DuneRepository', () => {
+  const ENV = process.env
+
+  beforeEach(() => {
+    process.env = { ...ENV }
+  })
+
+  afterAll(() => {
+    process.env = ENV
+  })
+
   it('needs DUNE_API_KEY', () => {
     delete process.env.DUNE_API_KEY
 
     expect(() => new DuneRepository()).toThrow('missing dune api key')
+  })
+
+  it('fetch query results', async () => {
+    const duneRepository = new DuneRepository()
+    const min = '3000'
+    const tokenAddress = '0xc18360217d8f7ab5e7c516566761ea12ce7f9d72'
+
+    jest.spyOn(duneRepository.dune, 'refresh').mockResolvedValueOnce({
+      // @ts-expect-error don't bother with the full response
+      result: {
+        rows: [...Array(faker.datatype.number({ max: 10 })).keys()].map(() => ({
+          address: faker.finance.ethereumAddress(),
+        })),
+      },
+    })
+    const { result } = await duneRepository.queryErc20Balance({
+      min,
+      tokenAddress,
+    })
+
+    expect(result?.rows).toBeDefined()
+    expect(result?.rows.length).toBeGreaterThan(0)
+    expect(result?.rows[0].address.startsWith('0x')).toBe(true)
   })
 })

--- a/apis/query/test/unit/DuneRepository.test.ts
+++ b/apis/query/test/unit/DuneRepository.test.ts
@@ -1,0 +1,9 @@
+import { DuneRepository } from '@repositories'
+
+describe('DuneRepository', () => {
+  it('needs DUNE_API_KEY', () => {
+    delete process.env.DUNE_API_KEY
+
+    expect(() => new DuneRepository()).toThrow('missing dune api key')
+  })
+})

--- a/apis/query/test/unit/QueryService.test.ts
+++ b/apis/query/test/unit/QueryService.test.ts
@@ -34,9 +34,12 @@ describe('Service', () => {
       jest
         .spyOn(DuneRepository.prototype, 'queryErc20Balance')
         .mockResolvedValueOnce({
-          columns: [],
-          data: addresses.map((address) => ({ address })),
+          // @ts-expect-error
+          result: {
+            rows: addresses.map((address) => ({ address })),
+          },
         })
+
       await expect(
         queryService.getErc20BalanceAnonSet({ min, tokenAddress }),
       ).resolves.toMatchObject(addresses)
@@ -46,6 +49,7 @@ describe('Service', () => {
       jest
         .spyOn(GraphRepository.prototype, 'getBeaconDepositors')
         .mockResolvedValueOnce(addresses)
+
       await expect(queryService.getBeaconDepositors()).resolves.toMatchObject(
         addresses,
       )
@@ -55,6 +59,7 @@ describe('Service', () => {
       jest
         .spyOn(GraphRepository.prototype, 'getPunkOwners')
         .mockResolvedValueOnce(addresses)
+
       await expect(queryService.getPunkOwners()).resolves.toMatchObject(
         addresses,
       )
@@ -64,6 +69,7 @@ describe('Service', () => {
       jest
         .spyOn(GraphRepository.prototype, 'getEnsProposalVoters')
         .mockResolvedValueOnce(addresses)
+
       await expect(
         queryService.getEnsProposalVoters({
           choice: 'FOR',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
 
   apis/query:
     dependencies:
+      '@cowprotocol/ts-dune-client':
+        specifier: ^0.0.1
+        version: 0.0.1
       '@google-cloud/bigquery':
         specifier: ^6.0.3
         version: 6.0.3
@@ -168,9 +171,6 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
-      dune-ts:
-        specifier: ^1.1.4
-        version: 1.1.4
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -2100,6 +2100,15 @@ packages:
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+    dev: false
+
+  /@cowprotocol/ts-dune-client@0.0.1:
+    resolution: {integrity: sha512-he5atCTdNU/uBF7utgJfqJnI0v0mJL7g0SiSyDySNgLnGMIbI9CvrzxKQXqJVQCbhreCICNMw879YcgwbaQ9uw==}
+    dependencies:
+      cross-fetch: 3.1.5
+      loglevel: 1.8.1
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /@cspotcode/source-map-support@0.8.1:
@@ -11971,11 +11980,6 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /dune-ts@1.1.4:
-    resolution: {integrity: sha512-169oUUmCY15unVOClf0UE2ZNo0OykcKd9NvjrfQ3Y5r0S6DquEAI+H/f3OWC7hzTlRO+KoyHZTNJH8jO4NGQ0w==}
-    engines: {node: '>=18'}
-    dev: false
-
   /duplexer3@0.1.5:
     resolution: {integrity: sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==}
     dev: false
@@ -17281,6 +17285,11 @@ packages:
       ansi-fragments: 0.2.1
       dayjs: 1.11.7
       yargs: 15.4.1
+    dev: false
+
+  /loglevel@1.8.1:
+    resolution: {integrity: sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==}
+    engines: {node: '>= 0.6.0'}
     dev: false
 
   /logplease@1.2.15:


### PR DESCRIPTION
# Description
Dune now offers his api for free accounts.
So we can use an API key with the community TS SDK [@cowprotocol/ts-dune-client](https://github.com/cowprotocol/ts-dune-client)) instead of my custom package [dune-ts](https://github.com/3pwd/dune-ts).

Closes #140 

## Behavior Changes

| Before | After |
| ------ | ----- |
|  `dune-ts` was going through the oauth flow, parsing cookies etc... to be able to make authenticated query requests. This was a bit inefficent, not robust      |  Use free dune API key with `@cowprotocol/ts-dune-client`. `DuneClient.refresh(queryId, parameters)` is all what is needed      |

# How has this been tested?

- new unit tests
-  api server ran locally and made an erc20 anon set request (eg http://localhost:3000/balance/ERC20?min=5000&tokenAddress=0xc18360217d8f7ab5e7c516566761ea12ce7f9d72)

# Checklist

- [x] I have performed a self-review of my code.
- [ ] All existing CI checks pass
  - My code compiles
  - My code follows the style guidelines of this project (code is linted and formatted)
  - My code doesn't break existing tests
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I added a reviewer for this pull request.
- [x] I have assigned myself to this pull request.
- [x] I have added the appropriate label(s) to this pull request.
